### PR TITLE
glance.html: editorial: replace "normative" tech spec with "full docu…

### DIFF
--- a/glance.html
+++ b/glance.html
@@ -113,7 +113,7 @@
 	</head>
 	<body>
 		<section id="abstract"> <!-- Abstract -->
-			<p>This page provides a paraphrased summary of the Web Sustainability Guidelines (<abbr title="Web Sustainability Guidelines">WSG</abbr>). For the normative technical specification, see <a href="https://w3c.github.io/sustainableweb-wsg/">https://w3c.github.io/sustainableweb-wsg/</a>.</p>
+			<p>This page provides a paraphrased summary of the Web Sustainability Guidelines (<abbr title="Web Sustainability Guidelines">WSG</abbr>). For the full document, see <a href="https://w3c.github.io/sustainableweb-wsg/">https://w3c.github.io/sustainableweb-wsg/</a>.</p>
 			<p>It aims to be a helpful entry point for individuals and affected parties who have an interest in digital sustainability and the work undertaken by the <a href="https://www.w3.org/groups/ig/sustainableweb/">Sustainable Web Interest Group</a>.</p>
 			<p>While this document does provide a quick summary of numerous key aspects of the WSG specification, it must be established that it in no way should be used as a replacement for following the guidelines and success criteria as laid out in the complete, long-form specification. Reasons for this include that this summary is neither intended to be in-depth nor feature-complete. Therefore, its role as an overview to help orientate affected parties to the specification's purpose in no way provides conformance to Web Sustainability criteria.</p>
 			<p>Help improve this page by sharing your ideas, suggestions, or comments via <a href="https://github.com/w3c/sustainableweb-wsg/issues/">GitHub issues</a>.</p>


### PR DESCRIPTION
…ment"

IGs don't produce anything normative, and the WSG are guidelines (as the name says) more than a technical specification where every feature is implemented by 2+ independent code-bases. 

Better to use wording like "full document" (which is also what we (Mozilla) use when linking from our summary of our Web Vision doc to the "full" version as it were, see top of https://www.mozilla.org/en-US/about/webvision/).