### PR TITLE
shortName fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,7 +344,8 @@
 			],
 			specStatus: "DNOTE",
 			noRecTrack: true,
-			latestVersion: "https://www.w3.org/TR/sustainableweb-wsg/",
+			shortName: "web-sustainability-guidelines",
+			latestVersion: "https://www.w3.org/TR/web-sustainability-guidelines/",
 			lint: { "local-refs-exist": false, },
 			postProcess: [authorRef, addMultipage, addFilter]
 		}


### PR DESCRIPTION
This fix changes our shortName to web-sustainability-guidelines as per @plehegar request (see the below ref).

https://github.com/w3c/transitions/issues/746#issuecomment-3338770176


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexDawsonUK/sustainableweb-wsg/pull/137.html" title="Last updated on Sep 26, 2025, 1:54 PM UTC (7043341)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/137/526bc02...AlexDawsonUK:7043341.html" title="Last updated on Sep 26, 2025, 1:54 PM UTC (7043341)">Diff</a>