### PR TITLE
Continuous publishing

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,20 @@
+# Example: Override respecConfig for W3C deployment and validators.
+name: Automatic Publication
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+jobs:
+  validate-and-publish:
+    name: Validate and Publish to TR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: index.html
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://github.com/w3c/sustainableweb-ig/blob/main/minutes/2025-09-25.md


### PR DESCRIPTION
This should hopefully setup Echidna on the repo for continuous publishing of TR drafts.