### PR TITLE
[DO NOT MERGE] Add snapshot of SCI-Web documents and consensus so far - 2025-12-04

### DIFF
--- a/sci-web/snapshot-2025-12-03/LICENSE
+++ b/sci-web/snapshot-2025-12-03/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Green Software Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sci-web/snapshot-2025-12-03/docs/initial-questionnaire.md
+++ b/sci-web/snapshot-2025-12-03/docs/initial-questionnaire.md
@@ -1,0 +1,11 @@
+Please answer the following questions and email your answers to harmony@greensoftware.foundation
+
+1.  Tell us about your journey to this table - what's your background, and what specific experience do you have with either website carbon measurement, the SCI standard, or sustainable web development?
+
+2. If we successfully adapt SCI for websites, what would that enable you or your organisation to do that you can't do today?
+
+3. What's one aspect of current website carbon measurement that keeps you up at night - whether it's a technical limitation, a methodological concern, or a practical implementation challenge?
+
+4. Are there any areas of controversy or uncertainty regarding website carbon measurement that you want to make sure gets tackled in the SCI for Web standard?
+
+5. Do you have any feedback on the research note shared above - what's missing, what did we get wrong? 

--- a/sci-web/snapshot-2025-12-03/docs/participant-handout.md
+++ b/sci-web/snapshot-2025-12-03/docs/participant-handout.md
@@ -1,0 +1,338 @@
+# SCI for Web Assembly - Participant Handout
+
+## **Summary**
+
+The SCI for Web Assembly is an **asynchronous, consensus-driven process** designed to develop the industry standard for measuring website carbon emissions. This assembly operates through **rapid 2-day email cycles** with GitHub transparency and selective live sessions only when objections cannot be resolved asynchronously.
+
+**SCI for Web details:** [https://assemblies.greensoftware.foundation/sci-for-web](https://assemblies.greensoftware.foundation/sci-for-web)
+
+---
+
+## **Key Dates & Timeline**
+
+* **Pre-Assembly Questionnaire:** September 15-22, 2025 (1 week)
+* **Consensus Building:** September 22 - December 1, 2025 (10 weeks)
+  * **Scope Definition:** Sept 22 - Oct 6 (2 weeks)
+  * **Quality Rubric:** Oct 6 - Oct 20 (2 weeks) 
+  * **Target Personas:** Oct 20 - Nov 3 (2 weeks)
+  * **Behavioral Incentives:** Nov 3 - Nov 17 (2 weeks)
+  * **Comparative Analysis:** Nov 17 - Dec 1 (2 weeks)
+* **Report Finalization:** December 1-8, 2025 (1 week)
+* **Total Duration:** Approximately 13 weeks
+* **Timeline Flexibility:** If consensus is reached faster on any area (e.g., 1 week instead of 2), the overall timeline may be shortened accordingly
+* **Capacity:** Maximum 20 participants
+* **Time Commitment:** 30 minutes every 2 days, work on your schedule
+
+---
+
+## **The Async-First Process**
+
+### **Core 2-Day Cycle**
+Every consensus area follows this rapid cycle:
+
+**Type 1: Question Emails**
+1. **Monday:** Engineered question email sent to all participants
+2. **Wednesday:** Free-form response deadline (2 days to respond - as detailed and wordy as you want)
+
+**Type 2: Synthesis Emails**  
+3. **Wednesday:** AI synthesis email sent back containing:
+   - Areas of agreement across all responses
+   - Areas of disagreement with specific participant positions
+   - Outlier viewpoints tagged to individuals
+   - Candidate statement for consensus
+4. **Friday:** Endorse/Consent/Object responses due
+5. **Repeat** synthesis cycles until consensus or escalate to live call
+
+### **Why 2-Day Cycles?**
+- **Maintains momentum** - no waiting weeks for responses
+- **Global accessibility** - enough time across all time zones  
+- **Forces focus** - prevents overthinking and analysis paralysis
+- **Creates urgency** - drives engagement and decision-making
+
+### **Sequential Consensus Areas**
+Each area **must** be completed before moving to the next due to dependencies:
+
+1. **Scope Definition** → *What applications are in/out of scope?*
+2. **Quality Rubric** → *How do we evaluate success within that scope?*
+3. **Target Personas** → *Who adopts this within scope for quality goals?*
+4. **Behavioral Incentives** → *What specific behaviors should personas change?*
+5. **Comparative Analysis** → *How do existing approaches measure against our framework?*
+
+---
+
+## **What Makes This Different**
+
+### **Boundary-Finding Focus**
+We're not seeking broad agreement - we're finding the **edges of boundaries**:
+- Where does "web application" end and "API" begin?
+- Which personas are **essential** vs nice-to-have?  
+- What quality criteria are **mandatory** vs optional?
+
+### **Engineered Questions**
+Each question is crafted to surface disagreement through:
+- **Opposing viewpoints** built into the question
+- **Edge cases** that force boundary decisions
+- **Artificial constraints** (e.g., "Pick only 3 personas")
+- **Implementation specifics** not just philosophy
+
+### **Two Types of Email Responses**
+
+**Question Email Responses:**
+- **Free-form response** to the question asked
+- **Encourage detailed, wordy responses** - more content helps AI synthesis
+- **No structure required** - just respond naturally to the question
+- **No endorse/consent/object** needed at this stage
+
+**Synthesis Email Responses:**
+Every synthesis includes a **candidate statement** you can:
+- **ENDORSE** - Actively support and advocate for (no rationale required)
+- **CONSENT** - Can live with, though not ideal (no rationale required)  
+- **OBJECT** - Cannot proceed without changes + **must explain what needs to change**
+
+---
+
+## **Participation Format**
+
+### **Pre-Assembly Materials & Questionnaire (1 Week)**
+**September 8-15, 2025**
+
+Before the assembly begins, you will receive:
+- **Pre-Assembly Questionnaire** (5 questions, 200 words each) - Separate questionnaire document
+- **Research Note** - GSF Head of Research & Development's analysis of current state-of-the-art in web carbon measurement, existing specifications, methodologies, and tools
+- **This Participant Handout** - Process guide and expectations
+
+*Response deadline: September 15, 2025*
+
+### **Consensus Building Phases (8 Weeks)**
+
+#### **Phase 1: Scope Definition (2 Weeks)**
+**September 22 - October 6, 2025**
+
+**Goal:** Crystal-clear boundaries for when to use SCI for Web vs other SCI specs
+
+**Key Boundary Questions:**
+- Single-page applications vs multi-page applications?
+- Client-side rendering vs server-side rendering?
+- Progressive web apps vs native mobile apps?
+- Web APIs called by websites vs standalone API services?
+- AdTech integrated in websites vs standalone AdTech platforms?
+
+**Success Criteria:** Clear in-scope/out-of-scope statement with edge cases resolved
+
+#### **Phase 2: Quality Rubric (2 Weeks)**  
+**October 6-20, 2025**
+
+**Goal:** Prioritized framework for evaluating SCI for Web effectiveness
+
+**Key Prioritization Questions:**
+- Measurement accuracy vs implementation simplicity?
+- Real-time measurement vs periodic assessment?
+- Cross-browser consistency vs platform optimization?
+- Developer usability vs procurement requirements?
+
+**Success Criteria:** Ranked quality criteria with clear evaluation methods
+
+#### **Phase 3: Target Personas (2 Weeks)**
+**October 20 - November 3, 2025**
+
+**Goal:** Essential adopter categories with specific behavioral targets
+
+**Key Persona Questions:**
+- Frontend developers vs full-stack developers vs DevOps?
+- Browser vendors vs hosting providers vs CDN operators?
+- Enterprise procurement vs startup teams vs open source maintainers?
+- **Constraint:** Maximum 5 primary personas allowed
+
+**Success Criteria:** Persona-behavior matrix showing who does what
+
+#### **Phase 4: Behavioral Incentives (2 Weeks)**
+**November 3-17, 2025**
+
+**Goal:** Specific behaviors SCI for Web should drive within defined scope
+
+**Key Incentive Questions:**
+- Smaller bundle sizes vs faster loading vs fewer requests?
+- Edge computing vs centralized hosting vs hybrid approaches?
+- Progressive enhancement vs single-page app optimization?
+- **Constraint:** Maximum 8 priority behaviors allowed
+
+**Success Criteria:** Ranked behavior list with persona mappings
+
+#### **Phase 5: Comparative Analysis (2 Weeks)**
+**November 17 - December 1, 2025**
+
+**Goal:** Evaluate existing approaches against our consensus framework
+
+**Key Analysis Questions:**
+- How do current carbon measurement tools align with our scope definition?
+- Which existing solutions meet our quality rubric requirements?
+- What gaps exist in current approaches for our target personas?
+- How well do existing tools drive our prioritized behavioral incentives?
+
+**Success Criteria:** Comprehensive analysis of existing landscape against consensus framework
+
+### **Report Finalization (1 Week)**
+**December 1-8, 2025**
+
+Consolidate all consensus decisions into final Assembly Report for publication.
+
+## **How to Participate**
+
+### **Question Email Responses**
+When you receive a question email:
+- **Reply directly to the email** with your thoughts
+- **Be as detailed and wordy as you want** - more tokens help AI synthesis
+- **No specific format required** - just respond naturally
+- **Submit by the stated deadline** (usually 2 days)
+
+### **Synthesis Email Responses**  
+When you receive a synthesis email with candidate statement:
+- **Reply with:** `ENDORSE`, `CONSENT`, or `OBJECT`
+- **For ENDORSE/CONSENT:** No additional explanation required (though optional)
+- **For OBJECT:** You MUST explain what needs to change for you to move to consent/endorse
+
+### **Object Response Requirements**
+If you object, your response must explain:
+- **What specifically you object to** in the candidate statement
+- **What needs to change** for you to move to consent or endorse  
+- **The path forward** you see for reaching consensus
+- **Your reasoning** - you must be prepared to defend your objection
+
+**Important:** Objecting is not casual. If you object, you're committing to help find a solution and participate in resolution discussions.
+
+### **Objection Resolution Process**
+
+1. **Object via synthesis email response** with detailed rationale of what needs to change
+2. **Additional synthesis rounds** incorporating all objection feedback into new candidate statements
+3. **Still objecting after multiple rounds?** → Mandatory live call scheduled
+4. **Live session attendance required** for people who endorsed AND people who objected
+5. **No consensus after 2 weeks?** → Proceed to supermajority vote
+6. **Vote outcome becomes final decision** and process moves to next consensus area
+
+---
+
+## **Meeting Philosophy**
+
+### **Standing Bi-Weekly Meetings**
+- **Reserved in your calendar** for full assembly duration
+- **Used ONLY for objection resolution** - not routine progress
+- **Mandatory attendance** if you've objected to the topic
+- **Optional attendance** for non-objecting participants
+- **72-hour notice** required for activation
+
+### **No Regular Meetings**
+- Primary work happens via **email + GitHub**
+- **Face-to-face interaction** only when async breaks down
+- **Global time zone friendly** - work on your schedule
+- **Documentation-driven** process with full transparency
+
+---
+
+## **Tools & Communication**
+
+### **Primary Channel: Email**
+- Structured question delivery every 2 days
+- Response collection with clear deadlines  
+- Synthesis summaries with candidate statements
+- Objection notices and resolution coordination
+
+### **Documentation: GitHub** 
+- All responses published with attribution
+- Complete decision audit trail maintained
+- Draft report.md updated in real-time
+- Pull request comments for retrospective changes
+
+### **Escalation: Zoom + Miro**
+- Live objection resolution sessions
+- Visual collaboration for complex disagreements
+- Recorded for absent participants
+- Used sparingly to maintain async benefits
+
+---
+
+## **The Living Report**
+
+### **REPORT.md File**
+- **Every consensus decision** is added to the `REPORT.md` file after consensus is reached
+- **Updated throughout assembly** as each consensus area completes
+- **Published publicly** only after the assembly is fully complete to GSF membership
+- **Not the specification** - this report drives what the specification will be
+- **Conversations remain private** - only consensus decisions are published
+
+### **Publication Timeline**
+- **Scope consensus** → Added to REPORT.md
+- **Quality rubric consensus** → Added to REPORT.md  
+- **Persona consensus** → Added to REPORT.md
+- **Behavioral incentives consensus** → Added to REPORT.md
+- **Comparative analysis consensus** → Added to REPORT.md
+- **Assembly completion** → REPORT.md published publicly to GSF membership and broader community
+
+---
+
+## **Participant Expectations**
+
+### **Your Commitment**
+- **Response discipline:** 2-day turnaround on all questions
+- **Boundary focus:** Help find edges rather than seek broad agreement  
+- **Implementation perspective:** Consider real-world deployment challenges
+- **Consensus support:** Honor agreed decisions even if not your preference
+- **GitHub engagement:** Review others' responses and synthesis summaries
+
+### **What We Provide**
+- **Structured process:** Clear methodology preventing deadlock
+- **Question engineering:** Crafted to surface productive disagreement
+- **AI synthesis:** Rapid processing of responses into actionable insights
+- **Escalation support:** Live facilitation when async reaches limits
+- **Documentation:** Complete record of all decisions and rationale
+
+---
+
+## **Success Metrics**
+
+### **Process Success**
+- Average 3-5 cycles per consensus area (rapid convergence)
+- <20% of topics require live objection sessions  
+- 100% participant response rate within 2-day windows
+- Clear consensus achieved on all 4 major areas
+
+### **Content Success**  
+- Sharp scope boundaries distinguishing SCI for Web from other specs
+- Implementable quality framework with measurable criteria
+- Actionable behavioral incentives mapped to specific personas
+- Foundation ready for formal specification development
+
+---
+
+## **FAQ**
+
+**Q: What if I miss a 2-day response deadline?**
+A: Contact [assemblies@greensoftware.foundation](mailto:assemblies@greensoftware.foundation) immediately. Synthesis proceeds without late responses, but you can still participate in subsequent rounds.
+
+**Q: Do I need to follow a specific format when responding to questions?**
+A: No format required for question emails - just respond naturally and be as detailed as you want. For synthesis emails, just reply with ENDORSE/CONSENT/OBJECT.
+
+**Q: What if I want to object but don't have a complete alternative solution?**
+A: You don't need a complete alternative, but you must explain what needs to change for you to move to consent/endorse. Focus on what's wrong and what direction would work better.
+
+**Q: Can I change my position between cycles?**
+A: Yes, until final consensus. Each synthesis round is a fresh opportunity to endorse, consent, or object based on the updated candidate statement.
+
+**Q: What happens if I object but can't attend the live session?**
+A: Objection sessions are mandatory for objectors. If you can't attend, you should either withdraw your objection or designate someone to represent your position.
+
+**Q: How binding are the report.md consensus decisions?**
+A: Very binding. Each consensus decision is immediately published and becomes the foundation for specification development. You're committing to support these outcomes.
+
+**Q: What's the difference between this report and the actual specification?**
+A: The report documents our consensus decisions and becomes the foundation for future specification development. The actual technical specification will be developed later by ongoing working groups.
+
+---
+
+## **Contact & Support**
+
+- **Process Questions:** [assemblies@greensoftware.foundation](mailto:assemblies@greensoftware.foundation)
+- **Technical Issues:** GitHub issues in the assembly repository
+- **Urgent Objections:** Direct contact with Chris Adams (Project Lead)
+- **Administrative:** Joseph Cook (Assembly Coordinator)
+
+**Ready to define the future of web carbon measurement?** Your expertise and engagement will shape how the industry measures and reduces website emissions for years to come.

--- a/sci-web/snapshot-2025-12-03/docs/research-brief.md
+++ b/sci-web/snapshot-2025-12-03/docs/research-brief.md
@@ -1,0 +1,124 @@
+# Website Carbon Measurement
+
+# Executive Summary
+
+Website carbon emission measurement has evolved significantly over the past few years. Today, the dominant methods for website carbon emissions measurements are the Sustainable Web Design Model v4 and, increasingly, the Software Carbon Intensity (SCI) standard adoption. However, both of these methods have significant limitations. Page weight is an imperfect proxy for emissions, and the SCI standard lacks specific guidance for web-specific applications. Here we’ll explore the current state of the art, compare the competing methodologies and point out opportunity areas where the SCI for Web might focus.
+
+## 1\. The Current Industry Standard
+
+### Sustainable Web Design Model v4
+
+The Sustainable Web Design Model (SWDM) v4, released July 2024, represents the current industry standard for website carbon calculations. It sums the contributions from three components to yield a website carbon emissions score in units of gCO2e/page view:
+
+- **Data centers**: 22% of system energy (290 TWh globally) \- 82% operational, 18% embodied emissions  
+    
+- **Networks**: 24% of system energy (310 TWh) \- 82% operational, 18% embodied emissions  
+    
+- **User devices**: 54% of system energy (421 TWh) \- 49% operational, 51% embodied emissions
+
+Version 4's calculation formula is as follows:
+
+```
+Average Emissions per Page View (gCO2e) = 
+[(OPDC × (1 - Green Hosting Factor) + EMDC) + (OPN + EMN) + (OPUD + EMUD)] × New Visitor Ratio) + ([(OPDC × (1 - Green Hosting Factor) + EMDC) + (OPN + EMN) + (OPUD + EMUD)] × Return Visitor Ratio × (1 - Data Cache Ratio))
+
+Where:
+
+OPDC – Operational Emissions Data Centers.
+Green Hosting Factor – The portion of hosting services powered by renewable or zero-carbon energy, between 0 and 1 (see FAQ).
+EMDC – Embodied Emissions Data Centers.
+OPN – Operational Emissions Networks.
+EMN – Embodied Emissions Networks.
+OPUD – Operational Emissions User Devices.
+EMUD – Embodied Emissions User Devices.
+New Visitor Ratio – The portion of first time visitors to a web page, between 0 and 1.
+Return Visitor Ratio – The portion of returning visitors to a web page, between 0 and 1. (What is this? See FAQ)
+Data Cache Ratio – The portion of data that is loaded from cache for returning visitors, between 0 and 1. (What is this? See FAQ)
+
+```
+
+Emissions estimates were reduced by 60-66% in Version 4 compared to Version 3\. Despite being the industry standard, SWDM v4 has faced criticism, especially around the suitability of page weight as a predictor of actual carbon emissions (e.g. [DebugBear, 2024](https://www.debugbear.com/blog/website-carbon-emissions)). 
+
+Other methodologies include the OneByte model, originating from The Shift Project, which offers simplicity but excludes significant emission sources. DIMPACT, developed by University of Bristol with industry partners, provides the most data-driven approach but requires a lot of data disclosure, which in turn relies upon extensive partner cooperation. The SCI standard is arguably the most comprehensive framework but it was designed for general software rather than websites, meaning it is lacking in specific guidance for measuring web applications.
+
+## 2\. Alternative Methodologies Comparison
+
+### Methodology Landscape
+
+The following table compares the main methodologies used to measure website carbon emissions today.
+
+| Dimension | SWDM v4 | OneByte Model | DIMPACT | SCI (ISO/IEC 21031:2024) |
+| :---- | :---- | :---- | :---- | :---- |
+| **Scope & Boundaries** | Cradle-to-grave: data centers, networks, user devices | Gate-to-gate: data centers and networks only | Complete digital media value chain | Flexible boundaries defined per software system |
+| **Primary Metric** | CO2e per page view | CO2e per byte transferred | Process-based emissions per media asset | Carbon intensity per functional unit |
+| **Formula Complexity** | Multi-factor with cache ratios and visitor types | Linear: Data × Energy × Carbon intensity | Activity-based with detailed process mapping | SCI \= ((E × I) \+ M) per R |
+| **Embodied Emissions** | Included: 18% for infrastructure, 51% for devices | Excluded | Included through detailed equipment inventory | Included (M component) with time/resource allocation |
+| **Functional Units** | Fixed: per page view | Fixed: per GB transferred | Flexible: per hour viewed, per asset delivered | Flexible: per user, transaction, API call, etc. |
+| **Energy Data Source** | Global averages: 0.055-0.080 kWh/GB by segment | Fixed: 0.06 kWh/GB (2018 data) | Actual measurements from partners | Real telemetry or lab measurements |
+| **Carbon Intensity** | Global average: 494g CO2e/kWh | User-selectable or global average | Regional grid factors | Location-specific, excludes market measures |
+| **Caching Consideration** | 75% new, 25% return with 98% cache efficiency | Not considered | Detailed CDN modelling | Not specified |
+| **Green Hosting** | Includes green hosting factor | Not considered | Actual energy sourcing data | Excludes renewable certificates |
+| **Validation Method** | Industry review, no empirical validation | Academic origin, limited validation | Industry \+ academic validation | Requires measurement documentation |
+| **Best Use Case** | General website assessment | Quick estimates, browser extensions | Media streaming and broadcasting | Software applications with clear boundaries |
+| **Key Limitation** | Page weight as imperfect proxy | Oversimplified, outdated factors | Complex data requirements | Requires adaptation for web contexts |
+
+## 3\. Refining the SCI Standard for Web
+
+The Software Carbon Intensity (SCI) standard (ISO/IEC 21031:2024) is calculated as:
+
+**SCI \= ((E × I) \+ M) per R**
+
+Where:
+
+- E \= Energy consumed by software system (kWh)  
+- I \= Location-based carbon intensity (gCO2eq/kWh)  
+- M \= Embodied carbon emissions from hardware  
+- R \= Functional unit (per user, transaction, request)
+
+### 
+
+The SCI has some key advantages over competing methodologies, including a scope that encompasses operational energy, carbon intensity, AND embodied emissions, flexibility in functional unit choice, an unopinionated approach to the route users take to measure E, I, M and R, exclusion of offsets (no “market based” measures allowed), detailed handling of hardware and recognition from ISO.
+
+However, the SCI specification is designed to apply broadly to all software, meaning there is a lack of particular guidance for websites. Some of the key areas of uncertainty are
+
+**Functional Unit Definition**: There are many units that could be appropriate for expressing website carbon emissions, for example page views, unique visitors, MAU, transactions, content delivery, API calls, etc. SCI does not currently give guidance regarding which functional units are appropriate for different web use cases.
+
+**Boundary Determination**: Modern websites are served on complex distributed infrastructure, including third-party scripts, CDNs, external APIs, client/server processing splits, and progressive web apps. SCI does not define where the system boundary lies.
+
+**Energy Measurement**: Users often have limited access to actual consumption data, especially in shared hosting environments, serverless architectures, etc, and SCI does not suggest appropriate proxies or methodologies for converting those proxies into energy estimates.
+
+**Embodied Emissions**: It is difficult to determine the appropriate physical resource-share for websites using shared infrastructure and user devices running thousands of applications. SCI currently only gives high level instructions for amortizing hardware emissions.
+
+## 4\. Opportunities for SCI for Web
+
+Based on the uncertainties identified above, these are some potential valuable deliverables for SCI for Web:
+
+- Provide a rubric for choosing an appropriate functional unit that addresses the main web architectures.  
+- Define an appropriate system boundary. Make it clear what components are in/out of scope for an SCI measurement.  
+- Provide a hierarchy of proxy data sources and recommended methodologies for converting them into E, I, M or R.  
+- Clarify the allocation strategy for hardware emissions, including for complex shared resources.  
+- Include a degree of cache-awareness.Differentiate new vs returning visitor impacts, account for CDN hit rates, browser caching etc.
+
+These could then be wrapped in the language of the SCI specification for submission to ISO.
+
+## 5\. SCI for Web case study
+
+**Cardamon**, developed by Root & Branch Digital, pioneered the first website measurement tool explicitly built to comply with the SCI standard (ISO/IEC 21031:2024). 
+
+Key features of Cardamon's SCI implementation:
+
+1. **Scenario-based measurement**: Cardamon is built around the concept of observations and scenarios. A scenario encapsulates a usage behaviour that you want to measure (e.g. add items to basket), compatible with ISO/IEC 21031 \- Software Carbon Intensity (SCI) specification.  
+     
+2. **Real power consumption tracking**: Unlike tools relying on data transfer proxies, Cardamon collects data every 2 seconds to measure actual power consumption of software processes, including Docker containers and bare-metal applications.  
+     
+3. **Functional unit flexibility**: Scenarios can represent any user behaviour, allowing measurement per transaction, per user action, or custom functional units as required by SCI.  
+     
+4. **Configuration-based approach**: Uses a `cardamon.toml` file to define:  
+   * CPU specifications with average power consumption  
+   * Processes to measure (Docker or bare-metal)  
+   * Scenarios representing user behaviours  
+   * Observations combining scenarios and processes  
+       
+5. **Iterative measurement**: Scenarios can be run multiple times to take an average, improving accuracy of carbon intensity calculations.
+
+This implementation addresses several SCI adaptation challenges for websites by providing scenario-based functional units, actual energy measurement rather than proxies, and support for distributed architectures through Docker container tracking. It is probably well worth engaging the developers of Cardamon to benefit from their experiences and understand their design decisions as we develop SCI for Web.

--- a/sci-web/snapshot-2025-12-03/docs/spec-template.md
+++ b/sci-web/snapshot-2025-12-03/docs/spec-template.md
@@ -1,0 +1,228 @@
+>IN DRAFT - DO NOT CHANGE
+
+## Scope
+
+```
+Define as it relates to Green Software Foundation Activity. If it adds clarity, define what is not in the scope. DELETE THIS COMMENT 
+```
+
+## References
+### Normative References
+
+```
+The policy for reference lists is:
+1. GSF documents listed should have at least one approved version – draft-only docs should not be referenced.
+An exception exists for documents approved with or after the referenced doc is approved (maybe part of the same enabler package). In short – approved docs should not reference unapproved docs.
+2. The name + version (no date) for GSF specifications are generally sufficient – dates should be used only if there is a specific reason to limit the usage.
+3. References to other affiliate docs should similarly provide sufficient information to uniquely determine the needed document and should provide the appropriate source information.
+4. The URL for GSF material (new GSF and affiliate) should always be http://www.greensoftware.foundation
+    
+Models to use:
+	[REFLABEL]	<General Model> "Ref Title", Ref information (source, date, id), URL:http//<ref-source>/ 
+	[GSFDOC]	<GSF Model> "GSF Document Title",{ Version x.y,} Green Software Foundation™, GSF <docname>{    <version>}, URL:http//www.openmobilealliance.org/ 
+
+If there are no entries in the table – enter 'none' to be precise.
+
+DELETE THIS COMMENT
+```
+<table>
+  <caption>Normative References </caption>
+  <tbody>
+    <tr>
+      <td><strong>[RFC2119]</strong></td>
+      <td>"Key words for use in RFCs to Indicate Requirement Levels", S. Bradner, March 1997, URL:http://www.ietf.org/rfc/rfc2119.txt</td>
+    </tr>
+    <tr>
+      <td><strong>[RFC5234]</strong></td>
+      <td>"Augmented BNF for Syntax Specifications: ABNF", D. Crocker, Ed., P. Overell, Janury 2008, URL: https://tools.ietf.org/rfc/rfc5234.txt</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+Add/Remove reference rows as needed - DELETE This Row 
+```
+
+### Informative References
+
+```
+Check the version of the Dictionary you are using and update the reference below. Delete the [GSFDICT] entry if the Dictionary is not used. In general, use the latest
+available version unless seeking alignment with an existing set of specifications.
+
+DELETE THIS COMMENT
+```
+<table>
+  <caption>Informative References </caption>
+  <tbody>
+    <tr>
+      <td><strong>[GSFDICT]</strong></td>
+      <td>"Dictionary for GSF Specifications", Version x.y, Green Software Foundation™, GSF-ORG-Dictionary-Vx_y, URL:http://greensoftware.foundation/</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+Add/Remove references as needed - DELETE This Row
+```
+
+## Terminology and Conventions
+### Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119].
+
+All sections and appendixes, except "Scope" and "Introduction", are normative unless they are explicitly indicated to be informative.
+
+```
+If needed, describe or declare using appropriate normative references the additional conventions that are used. DELETE THIS COMMENT
+```
+
+### Definitions
+
+```
+Add definitions in new rows of the following table as needed. The following examples show how dictionary references should be made as well as locally defined terms. This table should be maintained in sorted alphabetic order based on the labels of the terms.
+
+Examples:
+	Entity              Use definition #1 from [GSFDICT]
+	Interactive Service Use definition from [GSFDICT]
+	Local Term          The definition description would be presented directly
+
+DELETE THIS COMMENT
+```
+<table>
+  <caption>Definitions</caption>
+  <tbody>
+    <tr>
+	<td><strong>Definition-1</strong></td>
+	<td>Description definition-1</td>
+    </tr>
+    <tr>
+	<td><strong>Definition-2</strong></td>
+	<td>Description definition-2</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+Add/Remove definition rows as needed - DELETE This Row
+```
+
+Kindly consult [GSFDICT] for more definitions used in this document.
+
+### Abbreviations
+
+```
+Add abbreviations as needed. No special notation should be made regarding terms copied from the Dictionary.  
+The list should be maintained in alphabetic order. DELETE This Row
+```
+
+<table>
+<caption>Definitions</caption>
+<tbody>
+  <tr>
+    <td>GSF</td>
+    <td>Green Software Foundation</td>
+  </tr>
+</tbody>
+</table>
+
+## Introduction
+
+```
+From a market perspective...  
+
+* What can you do with this specification?
+* What problem does this solve?
+* How can this specification be applied?
+* Consider the target audience and provide deployment examples as possible.
+
+DELETE THIS COMMENT
+```
+
+### Version 1.0
+
+```
+This section provides a high level, concise and informative description of the main functionality supported in the initial version of the specification. The description should be brief; the target length should be a few paragraphs. 
+When the enabler or reference release is finished, this description should be aligned with the final functionality. 
+
+DELETE THIS COMMENT
+```
+
+### Version (x.y)
+
+```
+This section should be included for each new major or minor version of the specification.
+
+It should provide a high level, concise and informative description of the new or modified functionality introduced in this version of the specification, compared to the previous version. The description should be brief, and the target length should be a few paragraphs. When the enabler or reference release is finished, this description should be 
+aligned with the final functionality differences.
+
+DELETE THIS COMMENT
+```
+
+#### Version (x.y.z)
+
+```
+Service indicator (z) for the document. It is incremented every time a corrective update is made to the approved document version by the WG. This section should describe the main changes made to the specification at a high level compared to the previous version. The description should be brief, and the target length should be one paragraph.
+
+DELETE THIS COMMENT
+```
+
+## Sections As Needed
+
+```
+Sections for the normative specification text. Fill in as needed. The following validates the styles used for the headers. DELETE THIS COMMENT 
+```
+
+### Example Level 2
+(Add text here.)
+
+#### Example Level 3
+(Add text here.)
+
+##### Example Level 4
+(Add text here.)
+
+
+<table>
+  <caption>Example Table</caption>
+  <thead>
+      <tr>
+	  <th>Item</th>
+	  <th>Function</th>
+	  <th>Reference</th>
+      </tr>	      
+  </thead>	    
+  <tbody>
+    <tr>
+	<td>Row 1</td>
+	<td>Grid 1,1 data</td>
+	<td>Grid 1,2 data</td>	    
+    </tr>
+    <tr>
+	<td>Row 2</td>
+	<td>Grid 2,1 data</td>
+	<td>Grid 2,2 data</td>	    
+    </tr>
+  </tbody>
+</table>
+
+## Appendix Change History (Informative)
+
+### Approved Version x.y History
+
+<table>
+    <caption>Approved Version x.y History</caption>
+    <thead>
+        <tr>
+            <th>Reference</th>
+            <th>Date</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>    
+        <tr>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>No prior version</td>
+        </tr>
+    </tbody>
+</table>

--- a/sci-web/snapshot-2025-12-03/faq.md
+++ b/sci-web/snapshot-2025-12-03/faq.md
@@ -1,0 +1,67 @@
+# Scope
+
+## Q: Are Progressive Web Apps (PWAs) in scope for SCI for Web?
+
+Yes. PWAs that deliver functionality through browser-based interfaces fall within scope regardless of installability, offline capability, or service worker usage. The
+architectural characteristics of PWAs (web platform APIs, browser rendering engines, HTTP delivery) align with the core definitional criteria. Organizations should measure
+PWAs using the same methodology as traditional web applications, with cache behavior and offline functionality captured through standard measurement parameters.
+
+## Q: How do I classify an API service that has both programmatic access and a browser-based dashboard?
+
+Classify based on primary value delivery mode. If the browser dashboard is the main interface through which humans access the service's functionality, the entire system falls
+within SCI for Web scope. If the API serves primarily machine clients with the dashboard as a secondary administrative interface, use base SCI methodology. The determining
+factor is whether browser-mediated human interaction represents the primary usage pattern, not merely whether a browser interface exists.
+
+## Q: Does SCI for Web apply to Electron or Tauri desktop applications?
+
+Depends on architectural dependency. Applications that function as browser-based web applications wrapped in native containers (like Slack desktop, which requires continuous
+server connectivity for core value delivery) fall within scope. Applications providing substantial standalone functionality with local file system integration and offline
+capability (like VS Code) are out of scope and should use base SCI methodology. The classification depends on whether the application fundamentally operates as a web
+application with a native wrapper versus a native application using web rendering technologies.
+
+## Q: Are static content websites like blogs or documentation sites in scope?
+
+Yes. Static content websites that deliver information to human users through browser rendering over HTTP/HTTPS protocols meet the core scope criteria. While these sites may
+have minimal interactivity, they deliver functional value (content consumption) through browser-based interfaces. The scope intentionally includes the full spectrum from
+passive content delivery to highly interactive applications to ensure comprehensive coverage of browser-based software.
+
+## Q: What are examples of applications that fall OUTSIDE the SCI for Web scope?
+
+Native mobile applications: Apps downloaded from app stores that use native UI frameworks (Swift UI, Jetpack Compose) rather than browser rendering engines fall outside scope,
+even if they consume web APIs. Use base SCI methodology.
+
+Desktop applications: Standalone software using native rendering (Microsoft Office, Adobe Creative Suite) is out of scope, even if internet-connected. Use base SCI
+methodology.
+
+Pure backend services: APIs, microservices, databases, and processing systems accessed only by other software (not through browser interfaces) fall outside scope. Use base SCI
+methodology.
+
+IoT and embedded systems: Smart home devices, industrial controllers, and embedded systems operating without browser-based interfaces are out of scope, even if networked. Use
+base SCI methodology.
+
+Command-line tools: Terminal applications and CLI utilities accessed through shell interfaces rather than browsers fall outside scope. Use base SCI methodology.
+
+The key distinction: Applications fall outside SCI for Web scope when they fail one or more of the three core criteria: (1) HTTP/HTTPS protocol delivery, (2) browser rendering
+environment, or (3) human interaction through browser interfaces. These applications should use the base SCI methodology instead.
+
+## Q: How should I classify emerging technologies like voice interfaces, AR/VR, or future interaction paradigms?
+
+Apply the three core definitional criteria regardless of interaction modality:
+
+Voice interfaces to web applications: If users access a web application through voice commands that are processed by a browser-based interface (e.g., voice search on a
+website, voice control of a web dashboard), this remains in-scope. The browser still mediates the interaction and renders the interface, even if voice is an input method.
+
+AR/VR web experiences: WebXR applications delivered through browsers via HTTP/HTTPS and rendered by browser engines fall within scope, regardless of immersive interaction
+paradigms. The delivery mechanism and rendering context determine scope, not the presentation modality.
+
+Future technologies: As technology evolves, classify based on these principles:
+- Protocol delivery: Does it use HTTP/HTTPS delivery?
+- Rendering context: Does it use browser or web rendering engines?
+- Human interaction: Do humans consume value through that rendered interface?
+
+If all three criteria are met, the application falls within SCI for Web scope. This technology-agnostic approach ensures the specification remains relevant as interaction
+paradigms evolve, without requiring constant redefinition. The focus on delivery mechanism and rendering context, rather than specific input/output modalities, provides
+stability across technological change.
+
+Platform-independence principle: The scope intentionally avoids tying definitions to current interaction patterns (keyboard/mouse/touch) or display characteristics
+(rectangular screens). This future-proofs the specification for emerging interfaces while maintaining clear classification criteria.

--- a/sci-web/snapshot-2025-12-03/readme.md
+++ b/sci-web/snapshot-2025-12-03/readme.md
@@ -1,0 +1,37 @@
+# Software Carbon Intensity (SCI) for Web
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GSF Project](https://img.shields.io/badge/GSF-Standards_Project-brightgreen)](https://greensoftware.foundation)
+
+> **A specification addressing the challenges of measuring website carbon emissions**
+
+Created and managed by the [Software Standards Working Group](https://github.com/Green-Software-Foundation/software-standards-wg) in the [Green Software Foundation](https://greensoftware.foundation).
+
+## Scope
+
+The purpose of this proposed specification is to assist web practitioners and developers, designers, architects, and decision-makers in understanding and reducing the carbon footprint of web applications. By making informed choices about architecture, performance optimization, and deployment strategies, practitioners can minimize emissions while maintaining user experience.
+
+We will develop a methodology for calculating the carbon emissions rate (SCI score) of web applications, providing standardized functional units and clear boundaries between web applications and other domains (APIs, SaaS, AdTech). This specification aims to provide a reliable, consistent, and comparable measure that practitioners can use to set targets and track progress in reducing carbon emissions across the entire web stack from client devices through networking to server infrastructure.
+
+## Appointments
+
+The project is led by:
+* [Chris Adams (Green Web Foundation)](https://github.com/mrchrisadams)
+
+## Status
+
+> **This is a proposal Standard and has not been approved or adopted by the Green Software Foundation. This pre-draft may not be relied upon for any purpose other than review of the current state of development.**
+
+This project is being initiated through a Member Assembly starting September 8, 2025, with application deadline September 5, 2025 [[project page](https://directory.greensoftware.foundation/projects/software-carbon-intensity-for-web/)].
+
+## Copyright
+
+Standard WG projects are copyrighted under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+## License
+
+Software Standard WG projects are licensed under the MIT License - see the LICENSE file for details.
+
+## Patent
+
+Software Standard WG projects operate under the W3C Patent Mode.

--- a/sci-web/snapshot-2025-12-03/report.md
+++ b/sci-web/snapshot-2025-12-03/report.md
@@ -1,0 +1,734 @@
+# SCI for Web - Assembly Report
+
+**Status**: Draft Report from Assembly Process  
+**Version**: 1.0  
+**Date**: [Date]  
+**Contributors**: [List of assembly participants]
+
+---
+
+## Executive Summary
+
+[Brief 2-3 paragraph overview of the assembly process, key decisions made, and the path forward to formal specification development]
+
+---
+
+## 1. Scope Definition
+
+**Purpose**: This section defines what constitutes a "web application" for the purposes of SCI for Web measurement. It answers the question: "For whom and for which scenarios, use cases, applications, and audiences is this specification intended?"
+
+**What this section contains**:
+- Clear definition of "web application" based on architectural characteristics and interaction patterns
+- Principles for determining whether an application falls within scope
+- Statement of what is explicitly out of scope (e.g., native mobile applications, desktop software)
+
+**What this section does NOT contain**:
+- Lists of infrastructure components (servers, CDNs, databases)
+- Calculation methodologies or formulas
+- Classification of specific boundary cases or edge cases
+- Measurement procedures or implementation guidance
+
+**Constraints**:
+- Must align with parent SCI specification (cannot contradict SHALL/MUST/SHOULD requirements)
+- Must be narrow enough to be actionable, broad enough to cover legitimate use cases
+- Must represent consensus position from assembly participants
+
+---
+
+The SCI for Web specification applies to software applications that deliver functional value to human users primarily through browser-based interfaces accessed via HTTP/HTTPS protocols. A web application is characterized by three essential criteria: (1) content and functionality delivered over HTTP/HTTPS protocols, (2) rendering and execution occurring primarily within web browser environments or equivalent web rendering engines, and (3) interfaces designed for direct human interaction and consumption rather than exclusively machine-to-machine communication.
+
+The scope encompasses the full spectrum of browser-based applications regardless of architectural sophistication, including static content websites, dynamic platforms, single-page applications (SPAs), server-side rendered applications, e-commerce systems, media streaming services, and real-time collaborative tools. The distinguishing principle is browser-mediated human interaction: if users primarily access functionality through web browsers to accomplish tasks or consume content, the application falls within scope. This definition is intentionally platform-independent and technology-agnostic, focusing on delivery mechanism and user interaction patterns rather than specific implementation technologies.
+
+API-driven services require additional classification based on their primary access pattern. Pure machine-to-machine APIs serving only programmatic clients are out of scope and should use the base SCI methodology. However, APIs accessed primarily through browser-based interfaces—such as those with interactive documentation as the primary usage method or those coupled with browser-based management dashboards—fall within scope when the browser interface represents the primary human interaction mode. The determining factor is whether human users consume the service's value through browser rendering, not whether HTTP protocols are involved.
+
+---
+
+## 2. Target Personas
+
+**Purpose**: This section identifies the professional roles and organizational actors who should use this specification and whose behavior the measurement framework aims to influence.
+
+**What this section contains**:
+- Primary professional roles (e.g., sustainability engineers, frontend developers, DevOps engineers, product managers)
+- Secondary stakeholders (e.g., procurement officers, compliance teams, executives)
+- Organizational contexts where SCI for Web applies (e.g., SaaS providers, e-commerce platforms, media companies)
+- How different personas will use the specification (optimization decisions, reporting, vendor selection)
+- Decision-making power each role has (what they control vs. don't control)
+- Current barriers preventing them from prioritizing carbon
+
+**What this section does NOT contain**:
+- End-user personas (consumer vs. business users of web applications)
+- Geographic or demographic segmentation
+- Marketing or communications strategies
+
+**Why this matters**:
+We must know WHO we want to influence before we can design incentives or evaluation criteria. These personas have agency to reduce web carbon through their decisions.
+
+**Connection to other sections**:
+- Drives Behavioral Incentives (Section 3) - we design incentives for these specific roles
+- Informs Evaluation Criteria (Section 4) - we evaluate based on whether design serves these personas
+- Justifies Scope Definition (Section 1) - scope must be relevant to personas' work
+
+**Process note**: This section will be developed through consensus-building based on assembly discussions about who has agency to improve web application sustainability and who needs measurement frameworks to guide decisions.
+
+---
+
+The SCI for Web specification is designed for **technical practitioners who create and optimize browser-mediated web applications**, spanning both server-side infrastructure and client-side implementation. Because the agreed scope defines web applications through "browser-mediated human interaction via HTTP/HTTPS," the specification must serve personas who control energy consumption across the entire delivery chain—from servers generating responses to browsers rendering content for human users.
+
+### **Frontend Developers and Design Practitioners**
+
+These practitioners control the code, assets, and experiences delivered to browsers, directly affecting energy consumed on end-user devices during browser-mediated interactions. This includes:
+
+- **Frontend developers**: JavaScript bundle size and optimization, CSS efficiency, framework selection for client-side execution, third-party script integration, rendering performance, asset optimization (images, fonts, videos), progressive enhancement strategies, and client-side caching
+- **UX/UI designers**: Interface design decisions affecting resource consumption (infinite scroll vs. pagination, video backgrounds vs. static images, auto-playing media), interaction patterns determining data transfer frequency, content structure and information architecture
+- **Content designers**: Content strategy affecting page weight, media selection and optimization requirements, structured content delivery
+
+**What they control**: Client-side code efficiency, browser rendering performance, third-party client-side dependencies, asset delivery and optimization, user interaction patterns, content weight and structure, design decisions with 10x+ energy impact potential
+
+**What they don't control**: Server-side infrastructure location, database architecture, hosting provider selection, network infrastructure between datacenter and user, end-user device hardware specifications
+
+### **Backend and Infrastructure Engineers**
+
+These practitioners control server-side systems that generate and deliver content to browsers, affecting operational emissions from datacenters and infrastructure. This includes:
+
+- **Backend developers**: Server-side code efficiency, API design and optimization, database query performance, caching strategies, session management
+- **Infrastructure and systems engineers**: Cloud provider and geographic hosting location selection, server capacity planning and right-sizing, resource utilization policies, infrastructure architecture (static vs. dynamic provisioning), build and deployment pipeline efficiency (CI/CD, testing, artifact storage)
+- **Platform and DevOps engineers**: CDN configuration and edge caching, architectural patterns affecting server/client computation distribution (server-side rendering, static site generation, hybrid approaches), monitoring and observability systems, performance optimization tooling
+
+**What they control**: Server-side compute and storage resources, database efficiency and architecture, geographic hosting location and carbon intensity exposure, infrastructure capacity relative to actual traffic, deployment and build processes, caching at server and CDN levels, API efficiency
+
+**What they don't control**: End-user device choices, browser vendor implementations, client-side third-party script behavior (though can control whether to include them), market-based carbon offsets (excluded from SCI methodology)
+
+### **Product Owners and Technical Managers**
+
+These practitioners translate organizational goals into technical requirements and manage trade-offs between features, performance, and sustainability. This includes:
+
+- **Product owners and managers**: Feature prioritization and lifecycle management ("gardening"—pruning unnecessary features), performance budget setting, sustainability target definition, trade-off decisions between functionality and efficiency
+- **Technical leads and architects**: Architectural decision-making authority, technology selection across the stack, team capacity allocation for optimization work, supplier and third-party service selection criteria, non-functional requirements including performance and sustainability
+
+**What they control**: Which features get built and maintained, performance and sustainability budgets, team time allocation for optimization, supplier selection based on sustainability criteria, architectural standards and patterns
+
+**What they don't control**: Day-to-day implementation details, supplier internal implementations (though can switch suppliers), end-user behavior and device choices, industry-wide standards (though can advocate)
+
+### **Rationale: Connection to Scope**
+
+The agreed scope defines web applications as "browser-mediated human interaction" where "rendering and execution occur primarily within web browser environments." This explicitly requires measuring both server-side energy (generating responses) and client-side energy (rendering for human interaction). Frontend practitioners who control browser-delivered experiences are therefore equally essential to backend practitioners who control server infrastructure. Product roles provide the decision-making authority to prioritize sustainability work and set performance budgets that enable technical implementation.
+
+### **Critical Inclusion: Third-Party Dependencies and Transparency**
+
+Modern web applications depend extensively on third-party services for functionality (analytics, advertising, authentication, payments, CDNs, hosting). These dependencies consume energy on both servers and client devices. **Third-party services must be included within the SCI for Web boundary** to incentivize measurement, monitoring, and improvement of their performance and energy efficiency, encouraging them to reduce their own carbon emissions. Measurement and monitoring also provides the necessary data to make informed decisions about when and whether to select third-party services over first-party implementations.
+
+When precise energy data from third-party suppliers is unavailable, practitioners shall use industry default values with explicit disclosure that estimates were used. This approach balances comprehensiveness with implementation feasibility while creating market pressure for suppliers to provide transparency.
+
+**Supplier influence mechanism**: While practitioners cannot directly control third-party implementations, they exercise influence through vendor selection, contractual requirements for emissions transparency, and the collective market signal that sustainability performance affects purchasing decisions.
+
+### **Acknowledged but Not Primary Targets**
+
+**Suppliers and third-party service providers**: While their implementations significantly impact web application carbon footprint, they are users of this specification rather than its primary audience. The specification enables practitioners to pressure suppliers for transparency and better performance through informed vendor selection.
+
+**Standards bodies and regulatory authorities**: These entities set the broader context but are not the specification's implementation audience. The specification should align with existing standards (parent SCI methodology, accessibility guidelines) and support regulatory compliance without targeting these bodies as primary users.
+
+**End users and consumers**: These individuals have limited agency based on choices made by practitioners. User-facing interventions (sustainable mode toggles, carbon-aware delivery options) depend on practitioner implementation and are better addressed through choice architecture design than direct user targeting.
+
+---
+
+## 3. Implementation Practices and Incentives
+
+**Purpose**: This section documents what practices and optimizations the SCI for Web measurement framework encourages and discourages. It explains the design choices that align carbon reduction with business value and prevent perverse incentives.
+
+**What this section contains**:
+- **Desired practices**: Efficiency improvements, architectural optimizations, responsible vendor selection, quality-preserving carbon reduction
+- **Perverse incentives to avoid**: Quality degradation, cost-shifting to users, vanity metrics, gaming measurements
+- **Design choices**: How functional unit selection, boundary definitions, and measurement methodologies create proper incentives
+- **Trade-offs**: How the framework balances competing goals (accuracy vs. simplicity, comprehensiveness vs. feasibility)
+
+**Why this matters**:
+Measurement frameworks shape practices. If we measure the wrong things or measure them poorly, we incentivize harmful optimizations. This section makes explicit the practices and incentives underlying SCI for Web design.
+
+**Connection to other sections**:
+- Follows from Target Personas (Section 2) - we incentivize the identified professional roles
+- Informs Evaluation Criteria (Section 4) - evaluation assesses whether design achieves these incentives
+- Justifies Scope Definition (Section 1) - scope choices have implications for practices and incentives
+
+**Process note**: This section will be developed through consensus-building based on assembly discussions about optimization strategies, measurement concerns, and desired outcomes. It will also inform FAQ entries explaining why certain design choices were made.
+
+---
+
+This section defines the specific practices that SCI for Web should encourage or discourage in teams who measure and optimize web applications. These implementation practices guide design decisions throughout the specification, ensuring that measurement drives genuine carbon reduction rather than metric optimization.
+
+**Implementation Note**: While this section describes comprehensive practices across all system components, teams may adopt SCI for Web incrementally. Starting with measurable components (client-side and server-side infrastructure under direct control) and progressively expanding scope to include network transfer and third-party services is an acceptable path to comprehensive measurement. However, disclosed methodology must clearly identify which components are measured versus estimated versus excluded to maintain transparency and prevent gaming.
+
+**Note on Principles vs. Prescription**: The practices described below represent principles and patterns that reduce energy consumption. They are not prescriptive engineering requirements. Teams should evaluate these principles within their specific context and implement them using approaches appropriate to their architecture, constraints, and objectives.
+
+## Encouraged Practices
+
+### For Frontend Developers and Design Practitioners
+
+**Energy reduction outcomes targeted**: Reduce data transfer, reduce page weight, reduce client-side energy consumption, extend end-user device lifespan, reduce CPU/GPU utilization during rendering.
+
+**Energy reduction practices to encourage:**
+
+- **Optimize asset delivery**: Reduce bundle sizes, compress assets appropriately (images, videos, PDFs, audio files, and other media), eliminate unused CSS and JavaScript, implement code splitting, lazy-load non-critical resources
+- **Choose efficient rendering approaches**: Use progressive enhancement, implement server-side rendering or static generation where appropriate, minimize client-side computation for tasks that could run more efficiently on servers
+- **Design for efficiency**: Favor text over video or decorative image backgrounds, implement pagination over infinite scroll where appropriate, avoid auto-playing media, optimize animation performance, design effective user workflows that minimize unnecessary interactions
+- **Reduce third-party dependencies**: Minimize analytics scripts, advertising trackers, and external fonts; evaluate whether each third-party service provides sufficient value for its energy cost
+- **Optimize for diverse devices**: Test on low-end devices, implement responsive images, ensure experiences work efficiently across device capabilities
+- **Inform users**: Provide transparency about the environmental impact of using or overusing certain features, such as reverse logistics in e-commerce or continuous rendering of intensive visual assets
+
+**How these practices reduce energy:** Client-side optimizations directly reduce energy consumed on end-user devices (operational) and can extend device lifespan (embodied). Smaller data transfers reduce network energy. Efficient rendering reduces CPU/GPU utilization and battery drain. User transparency enables informed decision-making about feature usage.
+
+### For Backend and Infrastructure Engineers
+
+**Energy reduction outcomes targeted**: Minimize server-side resource usage, reduce datacenter electricity consumption, reduce CPU/memory/storage utilization, reduce network transmission distance and carbon intensity exposure.
+
+**Energy reduction practices to encourage:**
+
+- **Right-size infrastructure**: Match server capacity to actual load, avoid over-provisioning, implement auto-scaling that responds to real demand, decommission unused services, optimize underlying infrastructure choices such as VM instance types and image sizes
+- **Optimize database and API efficiency**: Design efficient database schemas, write efficient queries, implement appropriate indexing, reduce unnecessary data fetching, cache effectively, eliminate N+1 query patterns
+- **Choose efficient hosting**: Select hosting providers and regions based on carbon intensity and renewable energy availability, use edge computing to serve users from geographically closer locations
+- **Architectural efficiency**: Implement effective caching strategies (CDN, server-side, database), use content delivery networks appropriately, select efficient technology stacks
+- **Measure and monitor resource utilization**: Track actual CPU, memory, and storage usage; identify and eliminate wasteful operations; implement benchmarking during development and production phases
+
+**How these practices reduce energy:** Server optimizations directly reduce datacenter electricity consumption. Right-sizing reduces both operational energy and embodied emissions from idle hardware. Geographic hosting choices reduce both transmission distance and exposure to carbon-intensive grids. Benchmarking during development catches inefficiencies before production deployment.
+
+### For Product Owners and Technical Managers
+
+**Energy reduction outcomes targeted**: Prevent feature bloat that increases page weight and server load, establish performance constraints that limit energy consumption, incentivize vendor efficiency improvements through market pressure.
+
+**Energy reduction practices to encourage:**
+
+- **Practice "feature gardening"**: Regularly audit and remove low-value features that consume resources, resist feature bloat, prioritize quality over quantity
+- **Set performance and environmental budgets**: Establish and enforce limits on page weight, JavaScript execution time, and API response times that implicitly constrain energy consumption; define environmental budgets that track sustainability KPIs such as energy use, waste, and CO2 emissions thresholds in alignment with frameworks like GRI
+- **Make informed vendor decisions**: Select third-party services based on their efficiency and carbon transparency, require emissions data from vendors, switch to more efficient alternatives when available
+- **Allocate optimization time**: Provide team capacity for performance and efficiency work, treat optimization as ongoing maintenance rather than one-time effort
+- **Balance functionality with efficiency**: Make conscious trade-offs between feature richness and resource consumption, question whether new features justify their carbon cost
+- **Make carbon efficiency a quality attribute**: Implement non-functional requirements for carbon emissions, measure them, and use them as quality gates in development processes
+- **Prefer "always-available" over "always-on"**: Design systems so that resource-intensive features (like intensive rendering, data export, or batch processing) can be scheduled during low-carbon periods or rate-limited rather than running continuously at any time
+
+**How these practices reduce energy:** Product and management decisions determine what gets built and maintained. Removing unused features eliminates ongoing server costs and client-side execution. Performance and environmental budgets prevent gradual efficiency degradation. Vendor transparency requirements create market incentives for supplier optimization. Carbon-aware scheduling reduces emissions by timing computation to periods of lower grid carbon intensity.
+
+### For Third-Party Service Providers and Hosting Suppliers
+
+**Energy reduction outcomes targeted**: Reduce energy consumption per operation across all customer implementations, enable informed vendor selection through transparency, reduce grid carbon intensity through renewable energy procurement.
+
+**Energy reduction practices to encourage:**
+
+- **Provide transparency**: Publish energy consumption and carbon emissions data for services, offer APIs for customers to access real-time or historical emissions data
+- **Optimize implementations**: Invest in efficiency improvements that reduce energy per operation, implement efficient caching and content delivery
+- **Support customer measurement**: Provide detailed metrics on resource consumption, enable customers to attribute emissions accurately
+- **Procure renewable energy**: Procure renewable energy wherever possible for all energy-consuming activities. For datacenters, select low-carbon hosting locations and invest in energy efficiency improvements
+
+**How these practices reduce energy:** Supplier optimizations cascade across all customers. Transparency enables informed vendor selection. Renewable energy procurement reduces carbon intensity exposure for all customer workloads.
+
+## Discouraged Practices
+
+### Energy Displacement Rather Than Reduction
+
+**Practice to discourage:** Shifting computation from measured locations to unmeasured locations to improve metrics without reducing total system energy.
+
+**Examples:**
+- Moving computation from servers to client devices through heavy JavaScript to reduce measured server energy while increasing unmeasured client energy
+- Outsourcing computation to third-party services to externalize emissions from first-party measurements
+- Increasing build-time computation to reduce runtime computation (if development lifecycle is unmeasured)
+
+**Why this matters:** Displacement makes metrics look better while total system energy stays the same or increases. This is measurement gaming, not carbon reduction.
+
+**Design implication:** SCI for Web must measure comprehensively across servers, networks, third-party services, and end-user devices to close displacement pathways.
+
+### Quality Degradation as "Optimization"
+
+**Practice to discourage:** Reducing functionality, accessibility, security, privacy, or user experience to improve energy metrics.
+
+**Examples:**
+- Reducing image quality below acceptable thresholds to decrease data transfer
+- Removing accessibility, security, or privacy features to reduce the website payload
+- Limiting essential functionality to reduce computation
+- Degrading user experience (e.g., removing helpful features) to improve scores
+
+**Why this matters:** Measurements should incentivize delivering functionality efficiently, not delivering reduced functionality. Users accomplish the same tasks less efficiently or switch to less-efficient alternatives. Compromising accessibility, security, or privacy creates net harm that outweighs carbon benefits.
+
+**Design implication:** Functional units should measure energy per delivered functionality, not energy per technical operation. Multidimensional metrics capture quality-efficiency trade-offs.
+
+### Market-Based Measures Instead of Elimination
+
+**Practice to discourage:** Using carbon offsets, renewable energy certificates (RECs), or other market-based instruments to improve scores without reducing actual energy consumption.
+
+**Examples:**
+- Purchasing carbon offsets to neutralize emissions while maintaining inefficient operations
+- Buying RECs to claim "green" energy without reducing actual electricity use
+- Geographic arbitrage where applications claim low emissions by measuring only low-carbon regions while serving global users
+
+**Why this matters:** The parent SCI specification explicitly excludes market-based measures (see SPEC.md sections on Exclusions and Market-based Measures). The goal is eliminating emissions through efficiency, not compensating for inefficiency through financial instruments. As stated in the SCI specification: "Reducing an SCI score is only possible through the elimination of emissions."
+
+**Design implication:** SCI for Web measures energy consumption and carbon intensity based on actual infrastructure location and operation, without adjustments for offsets or certificates. Carbon intensity calculations use location-based grid intensity, excluding market-based measures as defined in the parent specification.
+
+### Measurement Gaming and Boundary Manipulation
+
+**Practice to discourage:** Optimizing measurement boundaries and methodologies to improve scores without reducing actual emissions.
+
+**Examples:**
+- Selectively excluding high-emission components from measurement scope
+- Choosing functional units that make inefficient operations appear efficient
+- Reducing essential activities (testing, security updates) to improve operational metrics
+- Cherry-picking measurement timeframes to avoid high-load periods
+
+**Why this matters:** Gaming destroys measurement credibility and prevents comparability. Organizations compete on measurement skill rather than actual efficiency.
+
+**Design implication:** Mandatory comprehensive boundaries, disclosed methodologies, and consistent functional units prevent gaming while allowing legitimate architectural diversity.
+
+### Vanity Metrics and Proxy Optimization
+
+**Practice to discourage:** Optimizing proxy metrics that correlate weakly with actual energy consumption.
+
+**Examples:**
+- Optimizing page weight without considering how assets are used (e.g., reducing rarely-loaded resources while ignoring frequently-loaded ones)
+- Focusing on first contentful paint while ignoring total page energy consumption
+- Reducing server response time by pushing computation to client without measuring total system impact
+- Optimizing for synthetic benchmarks that don't reflect real user usage patterns
+
+**Why this matters:** Proxy optimization can increase actual energy while improving measured proxies. Focus on proxies diverts attention from genuine efficiency improvements.
+
+**Design implication:** Where possible, measure actual energy consumption rather than proxies. When proxies are necessary, validate correlation with real energy impact and use multiple dimensions.
+
+## Design Implications for SCI for Web
+
+These implementation goals inform specific design decisions:
+
+**Comprehensive measurement boundaries:** To discourage displacement, SCI for Web must measure energy across servers, networks, third-party services, and end-user devices. Excluding any major component creates a displacement pathway.
+
+**Functional units measuring delivered functionality:** To discourage quality degradation, functional units should capture delivered functionality (transactions, content consumed, tasks completed) rather than just technical operations (page views, API calls).
+
+**Mandatory disclosure of methodologies:** To prevent boundary gaming, organizations must disclose what they measured, how they measured it, and what they excluded. This enables peer comparison and identifies gaming attempts.
+
+**Operational serving focus:** To avoid perverse incentives in development practices (reduced testing, delayed security patches), measure operational serving efficiency separately from development lifecycle efficiency.
+
+**Exclusion of market-based measures:** Following the parent SCI specification, SCI for Web excludes offsets, RECs, and other market-based instruments, focusing measurement on actual energy elimination through the three sustainability actions defined in the parent specification: energy efficiency, hardware efficiency, and carbon awareness.
+
+**Tiered implementation with disclosed sophistication:** To encourage adoption while maintaining comprehensive boundaries, allow organizations to start with industry defaults and increase measurement sophistication over time, with mandatory disclosure of which tier methodology is used.
+
+**Inclusion of embodied emissions:** To account for hardware manufacturing impacts and incentivize longer device lifespan and better resource utilization, include embodied emissions allocated proportionally to usage time, following the calculation methodology specified in the parent SCI specification.
+
+**Third-party service transparency requirements:** To pressure vendors for efficiency improvements, require including third-party services with vendor-provided data where available or conservative proxy estimates where unavailable.
+
+The overarching principle: SCI for Web design decisions should make practices that genuinely reduce total system energy the same practices that improve measured scores. When measurement and reality align, teams optimize actual efficiency rather than metrics.
+
+
+---
+
+## 4. Evaluation Criteria
+
+**Purpose**: This section defines what makes SCI for Web measurement credible, trustworthy, and worth implementing. It addresses the fundamental tension in sustainability measurement: scientifically rigorous specifications that nobody implements vs. imperfect but widely adopted measurements that actually reduce carbon.
+
+**What this section contains**:
+- Trade-offs between measurement accuracy and implementation simplicity
+- Trust and transparency requirements (what must be disclosed vs. what's optional)
+- Threshold criteria for usefulness (minimum accuracy, maximum complexity)
+- Gaming prevention principles (how to design out perverse incentives)
+- Success indicators (how we'll know if SCI for Web achieves its goals)
+- Implementation feasibility boundaries (what's too complex to expect adoption)
+
+**What this section does NOT contain**:
+- Detailed technical implementation specifications
+- Specific tooling requirements or recommendations
+- Prescriptive step-by-step procedures
+- Maturity tier definitions (those belong in the formal specification)
+
+**Why this matters**:
+The sustainability space is full of specifications that are scientifically correct but unused. This section explicitly addresses the adoption-accuracy trade-off and establishes what "good enough" looks like. We evaluate SCI for Web based on whether it incentivizes target personas toward identified behaviors while remaining implementable.
+
+**Key questions this section answers**:
+- How accurate does measurement need to be to drive behavior change?
+- How simple does implementation need to be for widespread adoption?
+- What disclosure is required for credibility without killing adoption?
+- What would make target personas reject or ignore SCI for Web?
+- Does the measurement framework achieve the behavioral incentives we identified?
+
+**Connection to other sections**:
+- Follows from Behavioral Incentives (Section 3) - we evaluate based on whether design achieves those incentives
+- Informed by Target Personas (Section 2) - evaluation considers implementability for those roles
+- Enables Comparative Analysis (Section 5) - provides criteria for assessing SCI for Web vs. alternatives
+
+**Process note**: This section will be developed through consensus-building based on assembly discussions about trust, implementation feasibility, and success criteria.
+
+---
+
+# Section 4: Evaluation Criteria - Merged Consensus Proposal
+
+## Overview
+
+This section establishes evaluation criteria for SCI for Web that balance scientific rigor with practical adoptability. The criteria recognize that unused specifications serve no one, while measurements lacking credibility undermine sustainability efforts. Our evaluation framework prioritizes defensible accuracy where teams have direct control, workflow integration over exceptional effort, and transparent limitations over false precision.
+
+The fundamental tension: scientifically rigorous specifications that nobody implements versus imperfect but widely adopted measurements that actually reduce carbon. SCI for Web must navigate this trade-off by being accurate enough to drive meaningful behavior change while simple enough for widespread adoption.
+
+## 1. The Accuracy-Adoption Trade-off
+
+### Sufficient Accuracy for Behavior Change
+
+SCI for Web does not require laboratory-grade precision to drive meaningful behavior change, but accuracy must be real, not merely perceived. Measurements inform decisions with carbon and ethical implications, making actual accuracy critical even as we acknowledge that perfect precision is unattainable.
+
+**Accurate enough to be defensible**: Measurements should enable teams to make informed decisions about which approaches genuinely reduce carbon emissions. When comparing options or tracking changes over time (comparing version A to version B, or approach X to approach Y), teams need confidence that observed differences reflect reality. A measurement framework showing that one implementation approach has 20% higher energy consumption than another warrants investigation and drives optimization; a framework showing 50% variance for equivalent implementations creates confusion and mistrust.
+
+The acceptable variance range depends on what teams have direct control over:
+- **Directly measured components** (browser execution, server operations teams manage): measurements within 10-15% of actual consumption enable confident decision-making
+- **Well-modeled components** with substantial real-world data backing (network transfer, user device diversity): measurements within 15-20% are acceptable as a starting point, with expectation of improvement as datasets grow
+- **Components with limited data availability**: clearly labeled placeholders and estimates are acceptable when they are explicitly marked as such, based on best available data and reasonable assumptions, documented with clear methodology, and accompanied by a path to improvement
+
+**Proportional to control and influence**: Accuracy requirements should scale with the degree of direct control teams have:
+- High accuracy for directly controlled elements (browser rendering from code teams write, server operations they manage)
+- Moderate accuracy for indirectly influenced elements (user behavior patterns, caching effectiveness, third-party services where vendor selection is controlled)
+- Explicit acknowledgment of uncertainty for uncontrolled elements (network infrastructure beyond origin servers, diverse user device characteristics)
+
+This proportionality principle aligns with the parent SCI specification's emphasis on actionable measurements that drive the three sustainability actions: energy efficiency, hardware efficiency, and carbon awareness.
+
+**Grounded in measurable reality**: Where direct measurement is feasible, it should be the foundation. Where modeling is necessary, it should be backed by substantial datasets from real-world observations, not theoretical assumptions. This follows the parent SCI specification's guidance: "The SCI encourages calculation using granular real-world data" while allowing "data generated through modeling, using best estimates" when real-world data is unavailable.
+
+### Implementation Simplicity for Widespread Adoption
+
+The parent SCI specification establishes as a core characteristic that "The SCI is easy to implement" and that "anyone without much experience or training shall be able to follow the SCI specification instructions." SCI for Web must honor this principle while addressing web-specific complexity.
+
+**Workflow integration**: The specification should work within existing tools and platforms—content management systems, CI/CD pipelines, analytics tools, monitoring systems. If adoption requires new toolchains separate from normal development workflows, it faces immediate organizational resistance. This aligns with Section 3's identified behavioral incentive: teams will only adopt measurement that integrates naturally into their existing practices.
+
+**Automation and standardization**: Manual measurement invites inconsistency and abandonment. High degrees of automation lower entry barriers, making adoption possible across the diverse roles identified in Section 2 (frontend developers, DevOps engineers, product managers) without specialized sustainability training.
+
+**Clear boundaries and minimal disruption**: Teams should understand exactly what they're measuring, why it matters, and what actions they can take. The specification should define clear scope boundaries that map to team responsibilities and capabilities identified in the Target Personas section.
+
+**Progressive sophistication**: Teams at different capability levels and organizational contexts should be able to adopt SCI for Web appropriately. Entry-level adoption with simpler methodologies should be legitimate and valuable, with clear pathways to more comprehensive measurement as capabilities mature. (Note: specific maturity tier definitions belong in the formal specification, not this evaluation criteria section.)
+
+## 2. Trust and Transparency Requirements
+
+### Mandatory Disclosure
+
+Credibility requires transparency about methodology, data sources, and limitations. The parent SCI specification requires that teams "Disclose the SCI score, software boundary, and the calculation methodology." SCI for Web extends this principle to web-specific contexts.
+
+**Methodology and assumptions**: The calculation approach, models used, and assumptions made must be explicitly documented. When placeholders, estimates, or constants are used, they must be clearly identified as such with justification for the chosen values. This enables peer review and prevents hidden gaming.
+
+**Data provenance**: Sources of data—whether from direct measurement, third-party services, reference devices, or public databases—must be disclosed. The chain from raw data to final calculation should be traceable. This follows the parent specification's emphasis on encouraging "the use of granular data."
+
+**Measurement boundaries**: What is included and excluded from the measurement must be explicit, following the parent specification's software boundary guidance. If third-party services are excluded, state this. If measurements only apply to specific user journeys or geographic regions, say so. This prevents boundary gaming identified in Section 3 as a discouraged practice.
+
+**Limitations and uncertainty**: Where accuracy cannot be assured, acknowledge it. Where control is limited, make it visible. Uncertainty ranges should be disclosed rather than hidden behind false precision. A single unconvincing component presented with false precision can discredit the entire framework.
+
+**Quantification method disclosure**: Following the parent SCI specification's procedure, teams must disclose whether they used measurement (real-world data) or calculation (models) for each component, and with what level of sophistication. This transparency enables comparability and prevents gaming through selective methodology choices.
+
+### Optional but Valuable Disclosure
+
+Beyond minimum requirements, teams should be encouraged to share:
+- Comparative analyses showing changes over time (aligning with parent specification's baseline comparison guidance)
+- Context about organizational constraints that affected measurement choices
+- Lessons learned about what drove adoption or created barriers
+- Improvement plans for advancing measurement sophistication
+
+## 3. Threshold Criteria for Usefulness
+
+### Minimum Accuracy Thresholds
+
+For SCI for Web to be useful for driving the behavioral incentives identified in Section 3, it must meet minimum accuracy standards:
+
+**For directly controlled components**: Where teams have direct control and measurement access (browsers they test with, servers they operate), accuracy should support confident decision-making. Measurements showing that implementation A has 10-15% higher energy consumption than implementation B should reliably indicate a genuine efficiency difference worth investigating.
+
+**For modeled components with strong data backing**: Where direct measurement isn't feasible but substantial real-world data exists (network transfer, user device diversity), models should produce results within 15-20% of actual consumption. This level of accuracy is sufficient to identify major inefficiencies and track directional improvement.
+
+**For components without adequate data**: Rather than presenting false precision, these should be explicitly marked as placeholders or rough estimates with wide uncertainty ranges, excluded from initial scope with a clear path to inclusion, or included with documented estimation methodology and clear improvement roadmap.
+
+The key principle: measurements must be accurate enough that optimizing the measured score reliably leads to actual carbon reduction, not merely metric improvement. This prevents the "vanity metrics and proxy optimization" practice discouraged in Section 3.
+
+### Maximum Complexity Boundaries
+
+Complexity kills adoption. The parent SCI specification emphasizes that calculation "shall be possible without incurring any cost, for instance, for data, services, or tooling." SCI for Web should respect these boundaries:
+
+**Parameter count**: The number of variables teams must track should be gatherable through normal development workflows. If gathering data requires dedicated data collection efforts beyond what teams already do for performance monitoring, expect resistance. This varies by organizational capability—what's feasible for a large enterprise may overwhelm a small team.
+
+**Calculation complexity**: The calculation should be explainable to a skeptical technical manager in under five minutes. The parent SCI specification's formula `SCI = (O + M) per R` is elegant; web-specific extensions should maintain this conceptual simplicity even when operational details are more involved. If it requires specialized knowledge to understand, it will be rejected when scrutinized.
+
+**Tool requirements**: Implementation should work with widely available, preferably open source tooling. Dependence on proprietary or expensive tools creates adoption barriers that contradict the parent specification's "easy to implement" principle and "no cost" requirement.
+
+**Progressive entry barriers**: Teams new to sustainability measurement should be able to start with automated tooling and industry defaults. As they mature, they can invest in more sophisticated measurement. But the entry barrier must be low enough that starting is feasible for the frontend developers, backend engineers, and product managers identified in Section 2.
+
+## 4. Gaming Prevention Principles
+
+Section 3 identified several discouraged practices: energy displacement, quality degradation, boundary manipulation, and vanity metrics. SCI for Web must be designed to prevent these forms of gaming while avoiding paralysis through over-complexity.
+
+### Design Against Gaming
+
+**Measure outcomes, not proxies**: Where possible, measure actual energy consumption rather than proxy metrics that can be optimized without real impact. This aligns with the parent SCI specification's focus on quantifying actual carbon emissions (operational plus embodied) rather than indirect proxies.
+
+**Comprehensive boundaries**: The parent specification states "The calculation of SCI shall include all supporting infrastructure and systems that significantly contribute to the software's operation." For web applications, this means measuring energy across servers, networks, third-party services, and end-user devices. Excluding major components creates displacement pathways where teams shift computation from measured to unmeasured locations without reducing total energy.
+
+**Functional units measuring delivered value**: To discourage quality degradation, functional units should capture delivered functionality (user tasks completed, transactions processed, content consumed) rather than just technical operations (page views, API calls). This follows the parent specification's guidance that R should describe "how the application scales" in terms meaningful to its purpose.
+
+**Avoid perverse incentives**: Ensure that optimizing for the SCI score aligns with genuine sustainability improvements. If the specification can be gamed by degrading user experience, shifting emissions elsewhere, or reducing essential quality attributes (accessibility, security, privacy), it will be gamed. Section 3 explicitly identifies these as discouraged practices.
+
+### Balanced Perspective on Gaming Risk
+
+Gaming is a real concern but should not cause design paralysis. Gaming requires effort, and for most teams, actually improving efficiency is easier than developing sophisticated gaming strategies. However, organizations facing performance pressure without strong sustainability culture may seek ways to show progress without actual improvement.
+
+The solution is not paralysis through over-complexity, but transparency and clear guardrails:
+- **Low-friction entry**: Make it easy to start measuring (reduces incentive to game by making genuine measurement easier than gaming)
+- **Mandatory disclosure**: Make methodology, boundaries, and quantification methods visible (makes gaming detectable)
+- **Clear improvement pathways**: Provide structured advancement to higher sophistication (channels competitive energy toward better measurement rather than gaming)
+- **Reputational accountability**: Market scrutiny and stakeholder pressure create natural disincentives for visible gaming
+
+### Design for Adversarial Defense
+
+The specification must withstand scrutiny from people motivated to reject it—technical skeptics, budget guardians, and organizational resistance to sustainability investment.
+
+**Defensible data foundation**: Every significant component should be traceable to direct measurements or well-documented datasets. Speculative models undermine credibility for the entire specification. As one participant noted, "In subjects where there are wider ethical or physical impacts, the actuality of those numbers moving is critical."
+
+**Scope alignment with control**: Teams should only be accountable for elements they can reasonably control or influence, as defined in Section 2's persona descriptions. Measuring things beyond their control creates grounds for rejection: "Why should I be measured on something I can't affect?"
+
+**Proportionate response to uncertainty**: Where uncertainty exists, acknowledge it rather than presenting false precision. As the parent specification acknowledges, access to data "might not always be available" and "modeling, using best estimates" is acceptable. Honest acknowledgment of uncertainty builds more trust than false precision.
+
+## 5. Success Indicators
+
+We will know SCI for Web succeeds when it drives the behavioral incentives identified in Section 3 and serves the target personas identified in Section 2.
+
+### Adoption Signals
+
+**Cross-organizational adoption**: Implementation occurs across different organizational contexts (SaaS providers, e-commerce platforms, media companies, small startups, large enterprises) without requiring extensive customization. This demonstrates that the specification serves diverse environments while maintaining consistency.
+
+**Multi-role engagement**: The diverse roles identified in Section 2 (frontend developers, backend engineers, DevOps practitioners, product managers) can integrate SCI for Web into their workflows without specialized training for entry-level adoption.
+
+**Sustained usage**: Teams continue measuring beyond initial implementation, indicating that the effort-to-value ratio is favorable. Measurement becomes part of normal development practice rather than a one-time compliance exercise.
+
+**Voluntary adoption**: Organizations adopt SCI for Web before regulatory or reputational pressure makes it mandatory, suggesting genuine perceived value. This aligns with the parent specification's goal of helping "users and developers make informed choices."
+
+**Progression over time**: Organizations advance from simpler to more sophisticated measurement approaches over time, demonstrating deepening commitment and capability.
+
+**Industry recognition**: SCI for Web becomes the default reference in articles, conferences, and discussions about web sustainability. Industry leaders publicly adopt and advocate for the specification.
+
+**Competitive and market pressure**: Organizations adopt SCI for Web because competitors are doing it, and not measuring becomes a competitive disadvantage. This market dynamic accelerates adoption without requiring regulatory mandates.
+
+**Regulatory incorporation**: Government sustainability requirements and industry standards reference SCI for Web as an acceptable methodology, validating the specification's credibility.
+
+### Impact Signals
+
+**Behavioral change evidence**: Observable changes in development practices—optimization decisions, architectural choices, vendor selection, infrastructure planning—driven by SCI for Web insights. This is the ultimate success metric: does measurement actually change what teams build and how they build it?
+
+**Credibility in skeptical contexts**: The specification withstands adversarial scrutiny from technically sophisticated skeptics, budget guardians, and auditors. When challenged, the measurement methodology is defensible with clear data provenance and reasonable assumptions.
+
+**Improvement over time**: As teams iterate, their SCI scores improve, indicating that measurement is driving meaningful efficiency gains. This follows the parent specification's baseline comparison guidance: teams should be able to demonstrate that actions taken reduced their SCI score.
+
+**Alignment with identified behavioral incentives**: The practices identified in Section 3 as encouraged (efficiency improvements, architectural optimization, responsible vendor selection, quality-preserving carbon reduction) are demonstrably incentivized by optimizing SCI for Web scores. Conversely, discouraged practices (energy displacement, quality degradation, boundary gaming) don't improve scores or are made visible through disclosure requirements.
+
+**Prioritization capability**: Organizations use SCI for Web measurements to build Marginal Abatement Cost (MAC) curves that help prioritize sustainability investments—identifying high-impact, low-effort improvements before tackling expensive, complex optimizations. This demonstrates that the measurement framework enables practical prioritization of the three sustainability actions defined in the parent specification: energy efficiency, hardware efficiency, and carbon awareness.
+
+**Carbon reduction at scale**: Aggregate carbon reduction across organizations implementing SCI for Web demonstrates real environmental impact. The parent specification states its purpose is "to help users and developers make informed choices... that will ultimately minimize carbon emissions." Success means actual emissions reduction, not just measurement sophistication.
+
+**Ecosystem emergence**: Tools, services, training, and consultancies built around SCI for Web create self-sustaining momentum and reduce implementation barriers over time. This ecosystem development indicates that the specification hit the right balance between rigor and adoptability.
+
+## 6. Implementation Feasibility Boundaries
+
+### What We Can Reasonably Expect
+
+The parent SCI specification acknowledges varying capabilities: "While teams should consider investing more time or money in calculating their SCI number to increase its accuracy," basic calculation "shall be possible without incurring any cost."
+
+**Universal expectations** (feasible for all organizations):
+- Automated measurement using open source tooling and reference devices for components under direct control
+- Integration into CI/CD pipelines for tracking changes over time
+- Documentation of methodology, boundaries, and limitations
+- Measurement of directly controlled components (browser environments they test, servers they operate)
+
+**Context-dependent expectations** (varies by organizational capability):
+- Mix of direct measurement and validated modeling for broader scope
+- Investment in measurement infrastructure proportional to organizational size and sustainability commitment
+- Expanded scope including network transfer and third-party estimation
+- Statistical validation and real-world user data integration
+
+This recognizes that the frontend developers at small startups and the sustainability engineers at large enterprises (both identified in Section 2) have vastly different resources while both needing to adopt SCI for Web.
+
+### What Is Too Complex to Expect Broadly
+
+**Universal real-time monitoring**: Continuous measurement of every component creates infrastructure and complexity burdens that most teams cannot sustain. This exceeds the parent specification's "easy to implement" principle.
+
+**Perfect accuracy across all components**: The parent specification acknowledges that "access to the data needed for higher resolution calculations might not always be available." Some components (diverse user devices, network infrastructure beyond origin servers, embodied emissions of user hardware) cannot be measured with high accuracy by most teams.
+
+**Custom hardware instrumentation**: Expecting teams to deploy specialized measurement hardware is unrealistic for widespread adoption and contradicts the "no cost" principle.
+
+**One-size-fits-all requirements**: Different organizational contexts face different constraints. A measurement methodology rigid enough to force uniformity will fail to achieve adoption across the diverse personas and contexts identified in Section 2.
+
+### Third-Party Service Disclosure
+
+Section 3 identifies third-party transparency as an encouraged practice for suppliers. Major third-party services (CDNs, analytics platforms, advertising networks, API services) should disclose carbon impact of their services. While full third-party measurement may not be feasible for most organizations, SCI for Web should create market pressure for this disclosure:
+
+- Entry-level adoption: Document third-party services used and their handling in methodology disclosure
+- Intermediate adoption: Estimate third-party impact using documented methodology (data transfer, API calls, etc.)
+- Advanced adoption: Incorporate third-party disclosure data where available, use validated estimation where not
+
+This approach balances comprehensiveness with implementation feasibility while creating market pressure for suppliers to provide transparency.
+
+### Embodied Emissions Considerations
+
+The parent SCI specification requires including embodied emissions: "An estimate of all the embodied emissions for the hardware used within the software boundary shall be included." For web applications, this is particularly challenging where user devices are entirely outside the application provider's control.
+
+**Feasible approach**: Include embodied emissions for infrastructure under direct control (owned servers, owned network equipment) using the parent specification's time-share and resource-share methodology. For user devices, use documented estimation approaches based on reasonable device lifecycle assumptions and average embodied emissions data, with clear disclosure of the estimation methodology used.
+
+This balances the parent specification's requirement with practical limitations while maintaining transparency.
+
+## 7. Connection to Behavioral Incentives
+
+The evaluation criteria directly enable the behavioral incentives identified in Section 3:
+
+**Efficiency improvements made visible**: By providing accurate measurement of directly controlled components, SCI for Web makes efficiency improvements visible and attributable, creating clear incentives for the optimization practices identified in Section 3 (asset optimization, code efficiency, database optimization, infrastructure right-sizing).
+
+**Architectural choices informed by evidence**: When architectural choices (caching strategies, rendering approaches, server/client computation distribution) show measurable impacts on SCI scores, teams gain concrete evidence to justify architectural investments identified in Section 3.
+
+**Vendor selection enabled**: Where third-party services can be measured or compared through disclosed data, SCI for Web enables the evidence-based vendor selection identified in Section 3 as an encouraged practice.
+
+**Quality preserved**: By measuring actual energy consumption for delivered functionality rather than crude proxies, SCI for Web rewards genuine efficiency rather than quality degradation masquerading as sustainability—explicitly preventing the discouraged practice identified in Section 3.
+
+**Prioritization enabled**: SCI for Web enables organizations to identify high-impact, low-effort improvements through Marginal Abatement Cost curve analysis, ensuring resources are directed efficiently toward the three sustainability actions defined in the parent specification.
+
+**Gaming prevented or exposed**: Through comprehensive boundaries and mandatory disclosure, the discouraged practices identified in Section 3 (energy displacement, boundary manipulation, vanity metrics) are either prevented by design or made visible through disclosure requirements.
+
+## 8. Key Principles Summary
+
+**Defensibility over comprehensiveness**: Better to measure a narrow scope accurately than claim broad coverage without credible data. Entry-level adoption measuring only directly controlled components is legitimately useful even with limited scope.
+
+**Integration over addition**: Success requires embedding into existing workflows, not adding new exceptional processes. This serves the diverse personas identified in Section 2.
+
+**Transparency about limitations**: False precision destroys credibility; honest acknowledgment of uncertainty builds trust. Mandatory disclosure prevents gaming and enables peer review.
+
+**Proportionate accountability**: Hold teams accountable only for what they can reasonably control and measure, as defined in Section 2's persona descriptions. This makes rejection less likely and adoption more feasible.
+
+**Adversarial resilience**: Design for skeptical scrutiny from technically sophisticated critics, budget guardians, and organizational resistance. Defensible data and transparent methodology withstand challenge.
+
+**Tangible value demonstration**: Show concrete benefits—cost savings, performance improvements, competitive advantage, prioritization capability—not just sustainability scores. This aligns incentives for adoption.
+
+**Progressive sophistication**: Enable entry at appropriate capability level while providing clear advancement pathways. All levels of sophistication are legitimate when honestly disclosed.
+
+**Real accuracy, not perceived**: Measurements must be real because sustainability has ethical and physical implications. As one participant emphasized, "the actuality of those numbers moving is critical."
+
+**Estimation with guardrails**: Estimation and placeholders are acceptable when clearly labeled, documented, and accompanied by improvement pathways. This follows the parent specification's allowance for modeling while maintaining transparency.
+
+**Market pressure for improvement**: Transparency, competitive pressure, and stakeholder expectations naturally encourage sophistication advancement and third-party disclosure over time.
+
+**Ecosystem enablement**: Lower entry barriers and clear standards enable ecosystem development (tools, services, training) that accelerates adoption and reduces future implementation costs.
+
+**Alignment with parent SCI specification**: All evaluation criteria honor the parent specification's core characteristics (sensitivity to sustainability actions, systems-impact view, ease of implementation, encouragement of granular data) and requirements (comprehensive boundaries, disclosure, exclusion of market-based measures).
+
+---
+
+## Conformance to Parent SCI Specification
+
+This evaluation criteria section aligns with the parent SCI specification's core characteristics and requirements:
+
+**Sensitivity to sustainability actions**: The accuracy thresholds and measurement approaches are designed to be sensitive to the three sustainability actions defined in the parent specification—energy efficiency, hardware efficiency, and carbon awareness. Actions that reduce energy consumption, improve hardware utilization, or leverage lower-carbon energy will improve SCI for Web scores.
+
+**Systems-impact view**: The emphasis on comprehensive boundaries and prevention of energy displacement ensures that SCI for Web takes the systems view required by the parent specification, preventing "local-level optimizations that might lead to negative downstream impacts."
+
+**Easy to implement**: The progressive sophistication approach and emphasis on workflow integration honor the parent specification's requirement that "anyone without much experience or training shall be able to follow the SCI specification instructions" and that calculation be "possible without incurring any cost."
+
+**Encouragement of granular data**: The accuracy thresholds and disclosure requirements encourage teams to use the most granular data available while allowing modeling when real-world data is unavailable, exactly as the parent specification prescribes.
+
+**Exclusion of market-based measures**: Gaming prevention explicitly prevents using offsets, RECs, or other market-based instruments to reduce scores, following the parent specification's exclusions section.
+
+**Disclosure requirements**: The mandatory transparency requirements extend the parent specification's procedure step 5: "Report: Disclose the SCI score, software boundary, and the calculation methodology."
+
+The evaluation criteria ensure that SCI for Web extends the parent specification to web-specific contexts while honoring all core principles and requirements.
+
+
+---
+
+## 5. Comparative Analysis
+
+**Purpose**: This section evaluates existing web sustainability measurement specifications and methodologies against the evaluation criteria, behavioral incentives, and target personas defined through assembly consensus. It provides evidence-based assessment of how SCI for Web compares to alternatives.
+
+**What this section contains**:
+- Overview of existing web measurement specifications and frameworks
+- Structured assessment of each specification against:
+  - Evaluation Criteria (Section 4) - accuracy/simplicity trade-offs, trust requirements, implementation feasibility
+  - Behavioral Incentives alignment (Section 3) - does it encourage desired behaviors and prevent perverse incentives?
+  - Target Personas coverage (Section 2) - does it serve the identified professional roles?
+  - Parent SCI specification compatibility (Section 1) - does it align with base SCI requirements?
+- Gap analysis identifying what existing approaches don't address
+- Positioning of SCI for Web relative to alternatives
+
+**What this section does NOT contain**:
+- Marketing comparisons or competitive positioning
+- Unsubstantiated criticism of other organizations' work
+- Claims without evidence-based justification
+
+**Methodology**:
+This section IS consensus-driven. Assembly participants will evaluate existing specifications against the criteria they've already established through previous rounds. The analysis will be structured as a scoring matrix, with participants providing assessments that are then synthesized into consensus scores.
+
+**Output format**:
+Matrix showing how each existing specification scores against the established evaluation criteria, with aggregated consensus scores and identified gaps.
+
+**Possible outcomes**:
+- Confirms need for new SCI for Web specification due to identified gaps
+- Identifies potential collaborations with existing initiatives
+- Determines whether existing specifications could be adapted rather than creating new standard
+- Clarifies unique value proposition of SCI for Web approach
+
+**Process note**: This section will be developed through structured consensus-building after Sections 1-4 are complete. Participants will score existing specifications against the criteria they've already agreed upon, producing a comparative assessment matrix.
+
+---
+
+This section evaluates existing frameworks and tools against the evaluation criteria established in Section 4. The assessment aims to understand current capabilities, identify gaps, and inform the development of SCI for Web specifications.
+
+Before presenting comparative scores, it's essential to understand what is being compared. These frameworks serve different purposes and exist at different maturity levels:
+
+| Framework | Type | Maturity Level | Primary Purpose | Last Major Update | Links |
+|-----------|------|----------------|-----------------|-------------------|-------|
+| **SWDM (Sustainable Web Design Model)** | Methodology / estimation model | Mature, stable | Carbon estimation methodology for web transfers using system-wide allocation | 2024 | [SWD Methodology](https://sustainablewebdesign.org/calculating-digital-emissions/) |
+| **CO2.js** | Open-source library (SWDM implementation) | Mature, stable | Programmatic implementation of SWDM for carbon estimation | 2024 (v13) | [CO2.js](https://github.com/thegreenwebfoundation/co2.js) |
+| **Website Carbon Calculator** | Web application (SWDM-based) | Mature, stable | Public awareness and single-page estimation using SWDM | 2023 | [Website Carbon](https://www.websitecarbon.com/) |
+| **Ecograder** | Automated testing tool (SWDM + Lighthouse) | Active development | Multi-dimensional web sustainability assessment using SWDM for carbon | 2024 (beta with WSG integration) | [Ecograder](https://ecograder.com/), [Beta](https://beta.ecograder.com/) |
+| **W3C WSG** | Living standard (W3C specification) | Active development | Comprehensive sustainability guidelines for web | Ongoing (2024) | [W3C Web Sustainability Guidelines](https://w3c.github.io/sustyweb/) |
+| **Parent SCI** | Technical specification (GSF standard) | Established, refinement phase | Generic software carbon intensity measurement framework | 2022 (v1.0) | [SCI Specification](https://sci.greensoftware.foundation/) |
+| **Cardamon** | Web application (SCI-compatible) | Active development | SCI-compatible web carbon measurement with ground truth validation | 2024 | [Cardamon App](https://web.cardamon.io), [Paper](https://cardamon.io/sci), [Core](https://github.com/Root-Branch/cardamon-core) |
+| **Green Metrics Tool** | Testing/CI platform (SCI implementation) | Mature, growing | SCI score calculation for web apps using observed hardware data | 2024 | [Green Metrics Tool](https://docs.green-coding.io), [SCI Docs](https://docs.green-coding.io/docs/measuring/carbon/sci/) |
+| **Greenspector** | Testing platform | Established (France) | Carbon intensity measurement linked to functional units, CI/CD integration | 2024 | [Greenspector](https://greenspector.com/en/publicationss/) |
+
+**IMPORTANT**: Not all frameworks listed above are independent. Several tools use the same underlying model, which is essential context for interpreting comparative scores.
+
+The following matrices evaluate each approach against evaluation criteria from Section 4, with additional practical adoption criteria identified through community feedback.
+
+**Scoring Scale:**
+- 5: Excellent - Fully meets criteria with strong evidence
+- 4: Good - Substantially meets criteria with minor gaps
+- 3: Adequate - Partially meets criteria with notable limitations
+- 2: Limited - Minimally addresses criteria with significant gaps
+- 1: Insufficient - Does not adequately address criteria
+- ~: Preliminary - Insufficient information for confident scoring
+
+### Core Evaluation Criteria (from Section 4)
+
+| Framework | Accuracy | Simplicity | Trust | Boundaries | Functional Units | Gaming Prevention | Personas | Incentives | **Core Avg** |
+|-----------|----------|-----------|-------|------------|------------------|-------------------|----------|------------|--------------|
+| **SWDM / CO2.js** | 3 | 5 | 4 | 4 | 2 | 2† | 3 | 3 | **3.3** |
+| **Website Carbon Calc** | 2 | 5 | 3 | 2 | 2 | 1† | 2 | 2 | **2.4** |
+| **Ecograder** | 3 | 4 | 3* | 3 | 2 | 2† | 3 | 3 | **2.9** |
+| **W3C WSG** | 2* | 2 | 3 | 3 | 3 | 2 | 4‡ | 4 | **2.9** |
+| **Parent SCI** | 3 | 2 | 4 | 4 | 3 | 3 | 4 | 4 | **3.4** |
+| **Cardamon** | 4 | 3 | 4 | 4 | 4 | 3 | 3 | 4 | **3.6** |
+| **Green Metrics Tool** | 4 | 2 | 5 | 4 | 5 | 4 | 3 | 4 | **3.9** |
+| **Greenspector** | ~4 | ~3 | ~4 | ~3 | ~4 | ~3 | ~3 | ~3 | **~3.4** |
+
+**Annotations:**
+- *W3C WSG Accuracy: Acknowledged to be improving with forthcoming measurement enhancements (no release date specified). Score may increase in future assessments.
+- *Ecograder Trust: Beta version now includes W3C WSG integration for improved guidance on specific improvements. Score reflects current production version capabilities.
+- ‡W3C WSG Personas: Filter system exists in full document mode to sort by category/role/discipline, reducing cognitive load. Upgraded filter system planned for main documentation.
+- †Gaming Prevention: Scores reduced by 1 point for SWDM-based frameworks (CO2.js, Website Carbon Calculator, Ecograder) that rely on automatic "green hosting" detection via IP/hosting provider lookup. This approach is deeply flawed for enterprise environments with CDNs and complex hosting architectures, enabling potential gaming through hosting provider selection signals rather than genuine carbon reductions.
+- ~Greenspector scores are preliminary assessments based on limited publicly available documentation. Full methodology review would enable confident scoring.
+
+**Note on SWDM-based tool scoring**: CO2.js, Website Carbon Calculator, and Ecograder share underlying SWDM methodology and therefore have similar accuracy, functional unit, and gaming prevention characteristics. Differences in other criteria reflect application-level distinctions (UI, additional features, documentation).
+
+SCI for Web should aim to maximise its average score on the above matrix, and ensure the average score exceeds any existing entry.
+
+---
+
+## Next Steps
+
+Based on this assembly report, the following actions are recommended:
+
+1. **Participant Vote**: Present consensus positions to assembly participants for validation
+2. **Project Charter Development**: If consensus is achieved, develop formal project charter for specification work
+3. **Glossary Formalization**: Create GLOSSARY.md with standardized definitions
+4. **FAQ Development**: Create FAQ.md addressing common questions and rationale
+5. **Specification Initiation**: Begin formal SCI for Web specification development with identified scope, quality criteria, and behavioral design
+
+---
+
+## Acknowledgments
+
+[Recognition of participants, facilitators, and supporting organizations]

--- a/sci-web/snapshot-2025-12-03/spec.md
+++ b/sci-web/snapshot-2025-12-03/spec.md
@@ -1,0 +1,1 @@
+(deliberately empty)


### PR DESCRIPTION
This PR exists to provide access to the generate documents so far during the SCI Web process, for sharing with the W3C Sustainable Web Interest group meetings, and to support discussion within that group.

The first few weeks have been focussed on identifying personas, what actions they are incentivised to do, and so on

You can leave comments on the PR, but you can also see the rendered content at the link below - this should be more readable.

Note **this is WIP, there is more work to tidy it up, but it seemed better to share now**

https://github.com/thegreenwebfoundation/sustainableweb-wsg/tree/ca-sci-web-snapshot-2025-12-04/sci-web/snapshot-2025-12-03


### What should I look at?

##### The main output far is the report

https://github.com/thegreenwebfoundation/sustainableweb-wsg/blob/ca-sci-web-snapshot-2025-12-04/sci-web/snapshot-2025-12-03/report.md

##### Some common FAQs

This is being set up now

https://github.com/thegreenwebfoundation/sustainableweb-wsg/blob/ca-sci-web-snapshot-2025-12-04/sci-web/snapshot-2025-12-03/faq.md

##### how the meetings have been run - how the GSF does standards work now

It's different from the W3C and uses an LLM to iteratively generate synthesised summaries of everyone's responses.

https://github.com/thegreenwebfoundation/sustainableweb-wsg/blob/ca-sci-web-snapshot-2025-12-04/sci-web/snapshot-2025-12-03/docs/participant-handout.md