### PR TITLE
Add explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -39,4 +39,4 @@ For content organization, currently by discipline, we previously considered orga
 
 ## Accessibility, Internationalization, Privacy, and Security Considerations
 
-Where applicable, accessibility, internationalization, privacy, and security have been considered throughout the development of the Web Sustainability Guidelines. [A list of guidelines to these areas](https://w3c.github.io/sustainableweb-wsg/#considerations) is available.
+Where applicable, accessibility, internationalization, privacy, and security have been considered throughout the development of the Web Sustainability Guidelines. [A list of guidelines to these areas](https://www.w3.org/TR/web-sustainability-guidelines/#considerations) is available.


### PR DESCRIPTION
For the TAG review, we'll need an explainer, a document that explains in clear language what we do, and covers what the problem is and how we solve it (see [explainer explainer](https://w3ctag.github.io/explainer-explainer/#introduction)). 

I've based this on [our summary](https://w3c.github.io/sustainableweb-wsg/summary.html) and our [abstract](https://w3c.github.io/sustainableweb-wsg/#abstract) and [introduction](https://w3c.github.io/sustainableweb-wsg/#introduction), focusing on the specific questions asked in the explainer explainer.