### PR TITLE
TAG: Subheading hotfix

### DIFF
--- a/guidelines.json
+++ b/guidelines.json
@@ -579,7 +579,7 @@
 					"id": "7",
 					"url": "https://www.w3.org/TR/web-sustainability-guidelines/#avoid-being-manipulative-or-deceptive",
 					"guideline": "Avoid being manipulative or deceptive",
-					"subheading": "Avoid using patterns, content, tools, or techniques that may artificially manipulate or deceive the user and waste energy.",
+					"subheading": "Avoid using patterns, content, tools, or techniques that may artificially manipulate or deceive the user.",
 					"criteria": [
 						{
 							"title": "Deceptive design patterns",

--- a/index.html
+++ b/index.html
@@ -829,7 +829,7 @@
 			</section>
 			<section> <!-- Avoid being manipulative or deceptive -->
 				<h3>Avoid being manipulative or deceptive</h3>
-				<p class="subheading">Avoid using patterns, content, tools, or techniques that may artificially manipulate or deceive the user and waste energy.</p>
+				<p class="subheading">Avoid using patterns, content, tools, or techniques that may artificially manipulate or deceive the user.</p>
 				<section class="notoc" data-materials="low" data-energy="low" data-water="low" data-emissions="low" data-standard="GPF, GR491, SDGs" data-considerations="Accessibility, Privacy, Security" data-categories="Assets, Compatibility, JavaScript, Patterns, Social Equity, UI, Usability">
 					<h4 id="deceptive-design-patterns">Success Criterion: Deceptive design patterns</h4>
 					<p class="external"><a class="urls" href="https://w3c.github.io/sustainableweb-wsg/resources.html#UX07-1">Resources</a></p>


### PR DESCRIPTION
TAG has made the below suggestion:

> I don't like "and waste energy" in this guideline: the sustainability implications of manipulation and deception are more around how lost trust undermines future relationships, than the environmental resources used to recover from the bad behavior.

This makes sense for this guideline so the "and waste energy" has been removed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexDawsonUK/sustainableweb-wsg/pull/235.html" title="Last updated on Feb 20, 2026, 1:17 PM UTC (2482bde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/235/efe7c4b...AlexDawsonUK:2482bde.html" title="Last updated on Feb 20, 2026, 1:17 PM UTC (2482bde)">Diff</a>