### PR TITLE
TAG: Title update for 2.16

### DIFF
--- a/benefits.html
+++ b/benefits.html
@@ -235,7 +235,7 @@
 						<li><strong>Privacy:</strong> Collecting informed consent and providing helpful disclosures about cookies, data collection, and data processing within forms, alongside appropriate links to find further information in an accessible format, improves data privacy.</li>
 					</ul>
 				</div>
-				<p><strong>Guideline <a href="https://www.w3.org/TR/web-sustainability-guidelines/#provide-useful-notifications">2.16</a></strong>: Provide useful notifications</p>
+				<p><strong>Guideline <a href="https://www.w3.org/TR/web-sustainability-guidelines/#avoid-unwanted-notifications">2.16</a></strong>: Avoid unwanted notifications</p>
 				<div class="summary">
 					<ul>
 						<li><strong>Accessibility:</strong> Signposting individuals to information through helpful notifications or error messages will reduce abandonment. All information must be presented in a way that does not discriminate, as this could exclude many potential users.</li>

--- a/glance.html
+++ b/glance.html
@@ -206,7 +206,7 @@
 						<ul>
 							<li>Create a <a href="https://www.w3.org/TR/web-sustainability-guidelines/#minimize-non-essential-content-interactivity-or-journeys">lightweight experience</a>, using <a href="https://www.w3.org/TR/web-sustainability-guidelines/#use-a-design-system-for-interface-consistency">a design system for interface consistency</a> that ensure navigation and way-finding <a href="https://www.w3.org/TR/web-sustainability-guidelines/#ensure-that-navigation-and-wayfinding-are-well-structured">are well-structured</a>, the user's <a href="https://www.w3.org/TR/web-sustainability-guidelines/#design-to-assist-and-not-to-distract">attention is respected</a> and <a href="https://www.w3.org/TR/web-sustainability-guidelines/#avoid-being-manipulative-or-deceptive">users are not manipulated</a>.</li>
 							<li>Implement forms that are <a href="https://www.w3.org/TR/web-sustainability-guidelines/#provide-accessible-usable-minimal-web-forms">usable, accessible, and minimal</a> and <a href="https://www.w3.org/TR/web-sustainability-guidelines/#validate-form-errors-and-account-for-tooling-requirements">assist users with errors</a>.</li>
-							<li>Only implement <a href="https://www.w3.org/TR/web-sustainability-guidelines/#provide-useful-notifications">useful notifications</a> that improve the user's experience.</li>
+							<li>Only implement <a href="https://www.w3.org/TR/web-sustainability-guidelines/#avoid-unwanted-notifications">useful notifications</a> that improve the user's experience.</li>
 						</ul>
 						<p>In relation to <strong>content and assets</strong>, make sure you:</p>
 						<ul>

--- a/guidelines.json
+++ b/guidelines.json
@@ -1451,8 +1451,8 @@
 				},
 				{
 					"id": "16",
-					"url": "https://www.w3.org/TR/web-sustainability-guidelines/#provide-useful-notifications",
-					"guideline": "Provide useful notifications",
+					"url": "https://www.w3.org/TR/web-sustainability-guidelines/#avoid-unwanted-notifications",
+					"guideline": "Avoid unwanted notifications",
 					"subheading": "Ensure any required notifications or alerts are clearly explained before activation, and that the user can both control and change them.",
 					"criteria": [
 						{

--- a/index.html
+++ b/index.html
@@ -1204,8 +1204,8 @@
 					</div>
 				</section>
 			</section>
-			<section> <!-- Provide useful notifications -->
-				<h3>Provide useful notifications</h3>
+			<section> <!-- Avoid unwanted notifications -->
+				<h3>Avoid unwanted notifications</h3>
 				<p class="subheading">Ensure any required notifications or alerts are clearly explained before activation, and that the user can both control and change them.</p>
 				<section class="notoc" data-materials="medium" data-energy="low" data-water="medium" data-emissions="low" data-standard="GPF, GR491" data-considerations="Accessibility, Privacy" data-categories="JavaScript, UI, Usability">
 					<h4 id="need-for-notification">Success Criterion: Need for notification</h4>
@@ -3878,7 +3878,7 @@
 				<ul>
 					<li><a href="#avoid-being-manipulative-or-deceptive">2.7 Avoid being manipulative or deceptive</a></li>
 					<li><a href="#provide-accessible-usable-minimal-web-forms">2.15 Provide accessible, usable, minimal web forms</a></li>
-					<li><a href="#provide-useful-notifications">2.16 Provide useful notifications</a></li>
+					<li><a href="#avoid-unwanted-notifications">2.16 Avoid unwanted notifications</a></li>
 					<li><a href="#audit-and-test-for-bugs-or-issues-requiring-resolution">2.19 Audit and test for bugs or issues requiring resolution</a></li>
 					<li><a href="#give-third-parties-the-same-priority-as-first-parties-during-assessment">3.6 Give third parties the same priority as first parties during assessment</a></li>
 					<li><a href="#ensure-that-your-code-is-secure">3.15 Ensure that your code is secure</a></li>

--- a/quickref.html
+++ b/quickref.html
@@ -189,7 +189,7 @@
 					<p><strong>GRI:</strong> Medium (Materials) / Low (Energy) / Medium (Water) / Low (Emissions)</p>
 				</fieldset>
 				<fieldset>
-					<legend><a href="https://www.w3.org/TR/web-sustainability-guidelines/#provide-useful-notifications">2.16 Provide useful notifications</a></legend>
+					<legend><a href="https://www.w3.org/TR/web-sustainability-guidelines/#avoid-unwanted-notifications">2.16 Avoid unwanted notifications</a></legend>
 					<label><input type="checkbox"><span>Remove non-essential notifications. Justify and reduce email, text message (<abbr title="Short Messaging Service">SMS</abbr>), and other invasive or energy-intense notifications to what is necessary. Use notifications, such as alerts for new content, with care and restraint. Make sure the users understand and give informed consent.</span></label>
 					<label><input type="checkbox"><span>Allow users to adjust their own notification and messaging settings. Ensure the options to unsubscribe, log out, and close an account are available and visible. Optional notifications must be off by default and only activated upon user opt in. The user should be able to change their contact details.</span></label>
 					<p><strong>GRI:</strong> Medium (Materials) / Low (Energy) / Medium (Water) / Low (Emissions)</p>

--- a/resources.html
+++ b/resources.html
@@ -2462,7 +2462,7 @@
 						</ul>
 					</details>
 				</div>
-				<p><strong>Guideline <a href="https://www.w3.org/TR/web-sustainability-guidelines/#provide-useful-notifications">2.16</a></strong>: Provide useful notifications</p>
+				<p><strong>Guideline <a href="https://www.w3.org/TR/web-sustainability-guidelines/#avoid-unwanted-notifications">2.16</a></strong>: Avoid unwanted notifications</p>
 				<div class="summary">
 					<details> <!-- SC: Need for notification -->
 						<summary id="UX16-1">SC: Need for notification</summary>


### PR DESCRIPTION
TAG has made the below suggestion:

> The guideline text seems to encourage sending notifications, but the body is all about reducing notifications and letting users control which ones they get. Perhaps a title more like "Omit unwanted notifications" or "Only send desired notifications"?

I've made the change to "Avoid unwanted notifications" as that best reflects the text (and is in the spirit of TAG's suggested replacements).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexDawsonUK/sustainableweb-wsg/pull/237.html" title="Last updated on Feb 20, 2026, 1:38 PM UTC (320e2a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/237/efe7c4b...AlexDawsonUK:320e2a6.html" title="Last updated on Feb 20, 2026, 1:38 PM UTC (320e2a6)">Diff</a>