### PR TITLE
TAG: Examples update

### DIFF
--- a/guidelines.json
+++ b/guidelines.json
@@ -1447,6 +1447,7 @@
 							"emissions": "Low"
 						}
 					],
+					"example": "<form>\r\n\t<label for=\"choose\">Would you prefer a banana or cherry? (required)<\/label>\r\n\t<input id=\"choose\" name=\"i-like\" required \/>\r\n\t<button>Submit<\/button>\r\n<\/form>",
 					"tags": ["Accessibility", "HTML", "Privacy", "Social Equity", "UI", "Usability"]
 				},
 				{
@@ -1504,7 +1505,6 @@
 							"emissions": "Low"
 						}
 					],
-					"example": "<form>\r\n\t<label for=\"choose\">Would you prefer a banana or cherry? (required)<\/label>\r\n\t<input id=\"choose\" name=\"i-like\" required \/>\r\n\t<button>Submit<\/button>\r\n<\/form>",
 					"tags": ["Accessibility", "JavaScript", "Privacy", "UI", "Usability"]
 				},
 				{
@@ -1793,7 +1793,6 @@
 							"emissions": "Medium"
 						}
 					],
-					"example": "<link rel=\"prefetch\" href=\"\/articles\/\" as=\"document\">",
 					"tags": ["Accessibility", "Compatibility", "KPIs", "Performance", "Privacy", "Reporting", "Research", "Security", "Social Equity", "Software", "Strategy", "UI", "Usability"]
 				},
 				{
@@ -2678,7 +2677,7 @@
 							"emissions": "Medium"
 						}
 					],
-					"example": "<img src=\"image.png\" loading=\"lazy\" alt=\"\u2026\" width=\"200\" height=\"200\">",
+					"example": "<link rel=\"prefetch\" href=\"\/articles\/\" as=\"document\">",
 					"tags": ["Accessibility", "Assets", "CSS", "JavaScript", "Performance"]
 				},
 				{
@@ -4050,7 +4049,7 @@
 							"emissions": "Low"
 						}
 					],
-					"example": "<IfModule mod_deflate.c>\r\n\t<IfModule mod_setenvif.c>\r\n\t\t<IfModule mod_headers.c>\r\n\t\t\tSetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\\s*,?\\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding\r\n\t\t\tRequestHeader append Accept-Encoding \"gzip,deflate\" env=HAVE_Accept-Encoding\r\n\t\t<\/IfModule>\r\n\t<\/IfModule>\r\n\t<IfModule mod_filter.c>\r\n\t\tAddOutputFilterByType DEFLATE \"application\/atom+xml application\/javascript application\/json application\/ld+json application\/manifest+json application\/rdf+xml application\/rss+xml application\/schema+json application\/geo+json application\/vnd.ms-fontobject application\/wasm application\/x-font-ttf application\/x-javascript application\/x-web-app-manifest+json application\/xhtml+xml application\/xml font\/eot font\/opentype font\/otf font\/ttf image\/bmp image\/svg+xml image\/vnd.microsoft.icon image\/x-icon text\/cache-manifest text\/calendar text\/css text\/html text\/javascript text\/plain text\/markdown text\/vcard text\/vnd.rim.location.xloc text\/vtt text\/x-component text\/x-cross-domain-policy text\/xml\"\r\n\t<\/IfModule>\r\n\t<IfModule mod_mime.c>\r\n\t\tAddEncoding gzip              svgz\r\n\t<\/IfModule>\r\n<\/IfModule>",
+					"example": "<IfModule mod_deflate.c>\r\n\t<IfModule mod_setenvif.c>\r\n\t\t<IfModule mod_headers.c>\r\n\t\t\tSetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\\s*,?\\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding\r\n\t\t\tRequestHeader append Accept-Encoding \"zstd, gzip, br, deflate\" env=HAVE_Accept-Encoding\r\n\t\t<\/IfModule>\r\n\t<\/IfModule>\r\n\t<IfModule mod_filter.c>\r\n\t\tAddOutputFilterByType DEFLATE \"application\/atom+xml application\/javascript application\/json application\/ld+json application\/manifest+json application\/rdf+xml application\/rss+xml application\/schema+json application\/geo+json application\/vnd.ms-fontobject application\/wasm application\/x-font-ttf application\/x-javascript application\/x-web-app-manifest+json application\/xhtml+xml application\/xml font\/eot font\/opentype font\/otf font\/ttf image\/bmp image\/svg+xml image\/vnd.microsoft.icon image\/x-icon text\/cache-manifest text\/calendar text\/css text\/html text\/javascript text\/plain text\/markdown text\/vcard text\/vnd.rim.location.xloc text\/vtt text\/x-component text\/x-cross-domain-policy text\/xml\"\r\n\t<\/IfModule>\r\n\t<IfModule mod_mime.c>\r\n\t\tAddEncoding gzip              svgz\r\n\t<\/IfModule>\r\n<\/IfModule>",
 					"tags": ["Assets", "Networking", "Performance"]
 				},
 				{
@@ -4795,7 +4794,6 @@
 							"emissions": "Low"
 						}
 					],
-					"example": "Accept-Encoding: zstd, gzip, br, deflate",
 					"tags": ["Accessibility", "Content", "E-Waste", "Hardware", "Performance", "Privacy"]
 				}
 			]

--- a/index.html
+++ b/index.html
@@ -1198,6 +1198,14 @@
 								<dt>GRI 303: Water</dt><dd>Medium</dd>
 								<dt>GRI 305: Emissions</dt><dd>Low</dd>
 							</dl>
+							<p class="subtitle"><strong>Example</strong></p>
+							<pre class="nohighlight">
+								&lt;form>
+									&lt;label for="choose"&gt;Would you prefer a banana or cherry? (required)&lt;/label&gt;
+									&lt;input id="choose" name="i-like" required /&gt;
+									&lt;button>Submit&lt;/button&gt;
+								&lt;/form&gt;
+							</pre>
 							<p class="subtitle"><strong>Tags</strong></p>
 							<p>Accessibility, HTML, Privacy, Social Equity, UI, Usability</p>
 						</details>
@@ -1230,14 +1238,6 @@
 								<dt>GRI 303: Water</dt><dd>Medium</dd>
 								<dt>GRI 305: Emissions</dt><dd>Low</dd>
 							</dl>
-							<p class="subtitle"><strong>Example</strong></p>
-							<pre class="nohighlight">
-								&lt;form>
-									&lt;label for="choose"&gt;Would you prefer a banana or cherry? (required)&lt;/label&gt;
-									&lt;input id="choose" name="i-like" required /&gt;
-									&lt;button>Submit&lt;/button&gt;
-								&lt;/form&gt;
-							</pre>
 							<p class="subtitle"><strong>Tags</strong></p>
 							<p>JavaScript, Privacy, UI, Usability</p>
 						</details>
@@ -1354,10 +1354,6 @@
 								<dt>GRI 303: Water</dt><dd>Medium</dd>
 								<dt>GRI 305: Emissions</dt><dd>Medium</dd>
 							</dl>
-							<p class="subtitle"><strong>Example</strong></p>
-							<pre class="nohighlight">
-								&lt;link rel="prefetch" href="/articles/" as="document"&gt;
-							</pre>
 							<p class="subtitle"><strong>Tags</strong></p>
 							<p>Accessibility, Compatibility, KPIs, Performance, Privacy, Reporting, Research, Security, Social Equity, Software, Strategy, UI, Usability</p>
 						</details>
@@ -1790,7 +1786,7 @@
 							</dl>
 							<p class="subtitle"><strong>Example</strong></p>
 							<pre class="nohighlight">
-								&lt;img src="image.png" loading="lazy" alt="…" width="200" height="200"&gt;
+								&lt;link rel="prefetch" href="/articles/" as="document"&gt;
 							</pre>
 							<p class="subtitle"><strong>Tags</strong></p>
 							<p>Accessibility, Assets, CSS, JavaScript, Performance</p>
@@ -2436,7 +2432,7 @@
 									&lt;IfModule mod_setenvif.c&gt;
 										&lt;IfModule mod_headers.c&gt;
 											SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
-											RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+											RequestHeader append Accept-Encoding "zstd, gzip, br, deflate" env=HAVE_Accept-Encoding
 										&lt;/IfModule&gt;
 									&lt;/IfModule&gt;
 									&lt;IfModule mod_filter.c&gt;
@@ -2774,10 +2770,6 @@
 								<dt>GRI 303: Water</dt><dd>Low</dd>
 								<dt>GRI 305: Emissions</dt><dd>Low</dd>
 							</dl>
-							<p class="subtitle"><strong>Example</strong></p>
-							<pre class="nohighlight">
-								Accept-Encoding: zstd, gzip, br, deflate
-							</pre>
 							<p class="subtitle"><strong>Tags</strong></p>
 							<p>Accessibility, Content, E-Waste, Hardware, Performance, Privacy</p>
 						</details>


### PR DESCRIPTION
TAG has made the below suggestion regarding 2.16:

> The "Would you prefer a banana or cherry?" The example in Additional Information doesn't seem to match this guideline.

As a result I've gone through all of the examples and corrected any that don't align with the guidelines:
I've moved **2.16** to **2.15**, **2.19** has replaced **3.8** and **4.12** has been removed with **4.3**'s example updated as it had more current code.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexDawsonUK/sustainableweb-wsg/pull/238.html" title="Last updated on Feb 20, 2026, 1:49 PM UTC (279ca82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/238/efe7c4b...AlexDawsonUK:279ca82.html" title="Last updated on Feb 20, 2026, 1:49 PM UTC (279ca82)">Diff</a>