### PR TITLE
TAG: Subheading update for 2.17

### DIFF
--- a/guidelines.json
+++ b/guidelines.json
@@ -1511,7 +1511,7 @@
 					"id": "17",
 					"url": "https://www.w3.org/TR/web-sustainability-guidelines/#reduce-the-impact-of-downloadable-and-physical-documents",
 					"guideline": "Reduce the impact of downloadable and physical documents",
-					"subheading": "Reduce the need for physical documents as much as possible by allowing the saving of well-labeled, optimized digital downloads and having a print style sheet.",
+					"subheading": "Reduce the need for physical documents as much as possible by allowing the saving of well-labeled, optimized digital downloads. Include a print style sheet to avoid resource waste.",
 					"criteria": [
 						{
 							"title": "Printed documents",

--- a/index.html
+++ b/index.html
@@ -1246,7 +1246,7 @@
 			</section>
 			<section> <!-- Reduce the impact of downloadable and physical documents -->
 				<h3>Reduce the impact of downloadable and physical documents</h3>
-				<p class="subheading">Reduce the need for physical documents as much as possible by allowing the saving of well-labeled, optimized digital downloads and having a print style sheet.</p>
+				<p class="subheading">Reduce the need for physical documents as much as possible by allowing the saving of well-labeled, optimized digital downloads. Include a print style sheet to avoid resource waste.</p>
 				<section class="notoc" data-materials="medium" data-energy="low" data-water="medium" data-emissions="low" data-standard="GR491, GreenIT, OpQuast, SDGs" data-considerations="Accessibility" data-categories="Assets, Compatibility, Content, E-Waste, Hardware, HTML, Performance, Software, UI, Usability">
 					<h4 id="printing-documents">Success Criterion: Printed documents</h4>
 					<p class="external"><a class="urls" href="https://w3c.github.io/sustainableweb-wsg/resources.html#UX17-1">Resources</a></p>


### PR DESCRIPTION
TAG has made the below suggestion:

> 2.17 Reduce the impact of downloadable and physical documents
> "Reduce the need for physical documents as much as possible by … having a print style sheet." doesn't seem quite right. Maybe the print style sheet belongs in a separate sentence?

Therefore the copy has been updated to:

> Reduce the need for physical documents as much as possible by allowing the saving of well-labeled, optimized digital downloads. Include a print style sheet to avoid resource waste.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexDawsonUK/sustainableweb-wsg/pull/239.html" title="Last updated on Feb 20, 2026, 1:55 PM UTC (3d4a7de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/239/efe7c4b...AlexDawsonUK:3d4a7de.html" title="Last updated on Feb 20, 2026, 1:55 PM UTC (3d4a7de)">Diff</a>