### PR TITLE
[DO NOT MERGE] Add snapshot of SCI-Web spec documents so far - 2026-05-07

### DIFF
--- a/sci-web/FAQ.md
+++ b/sci-web/FAQ.md
@@ -1,0 +1,67 @@
+# Scope (DRAFT SNAPSHOT)
+
+## Q: Are Progressive Web Apps (PWAs) in scope for SCI for Web?
+
+Yes. PWAs that deliver functionality through browser-based interfaces fall within scope regardless of installability, offline capability, or service worker usage. The
+architectural characteristics of PWAs (web platform APIs, browser rendering engines, HTTP delivery) align with the core definitional criteria. Organizations should measure
+PWAs using the same methodology as traditional web applications, with cache behavior and offline functionality captured through standard measurement parameters.
+
+## Q: How do I classify an API service that has both programmatic access and a browser-based dashboard?
+
+Classify based on primary value delivery mode. If the browser dashboard is the main interface through which humans access the service's functionality, the entire system falls
+within SCI for Web scope. If the API serves primarily machine clients with the dashboard as a secondary administrative interface, use base SCI methodology. The determining
+factor is whether browser-mediated human interaction represents the primary usage pattern, not merely whether a browser interface exists.
+
+## Q: Does SCI for Web apply to Electron or Tauri desktop applications?
+
+Depends on architectural dependency. Applications that function as browser-based web applications wrapped in native containers (like Slack desktop, which requires continuous
+server connectivity for core value delivery) fall within scope. Applications providing substantial standalone functionality with local file system integration and offline
+capability (like VS Code) are out of scope and should use base SCI methodology. The classification depends on whether the application fundamentally operates as a web
+application with a native wrapper versus a native application using web rendering technologies.
+
+## Q: Are static content websites like blogs or documentation sites in scope?
+
+Yes. Static content websites that deliver information to human users through browser rendering over HTTP/HTTPS protocols meet the core scope criteria. While these sites may
+have minimal interactivity, they deliver functional value (content consumption) through browser-based interfaces. The scope intentionally includes the full spectrum from
+passive content delivery to highly interactive applications to ensure comprehensive coverage of browser-based software.
+
+## Q: What are examples of applications that fall OUTSIDE the SCI for Web scope?
+
+Native mobile applications: Apps downloaded from app stores that use native UI frameworks (Swift UI, Jetpack Compose) rather than browser rendering engines fall outside scope,
+even if they consume web APIs. Use base SCI methodology.
+
+Desktop applications: Standalone software using native rendering (Microsoft Office, Adobe Creative Suite) is out of scope, even if internet-connected. Use base SCI
+methodology.
+
+Pure backend services: APIs, microservices, databases, and processing systems accessed only by other software (not through browser interfaces) fall outside scope. Use base SCI
+methodology.
+
+IoT and embedded systems: Smart home devices, industrial controllers, and embedded systems operating without browser-based interfaces are out of scope, even if networked. Use
+base SCI methodology.
+
+Command-line tools: Terminal applications and CLI utilities accessed through shell interfaces rather than browsers fall outside scope. Use base SCI methodology.
+
+The key distinction: Applications fall outside SCI for Web scope when they fail one or more of the three core criteria: (1) HTTP/HTTPS protocol delivery, (2) browser rendering
+environment, or (3) human interaction through browser interfaces. These applications should use the base SCI methodology instead.
+
+## Q: How should I classify emerging technologies like voice interfaces, AR/VR, or future interaction paradigms?
+
+Apply the three core definitional criteria regardless of interaction modality:
+
+Voice interfaces to web applications: If users access a web application through voice commands that are processed by a browser-based interface (e.g., voice search on a
+website, voice control of a web dashboard), this remains in-scope. The browser still mediates the interaction and renders the interface, even if voice is an input method.
+
+AR/VR web experiences: WebXR applications delivered through browsers via HTTP/HTTPS and rendered by browser engines fall within scope, regardless of immersive interaction
+paradigms. The delivery mechanism and rendering context determine scope, not the presentation modality.
+
+Future technologies: As technology evolves, classify based on these principles:
+- Protocol delivery: Does it use HTTP/HTTPS delivery?
+- Rendering context: Does it use browser or web rendering engines?
+- Human interaction: Do humans consume value through that rendered interface?
+
+If all three criteria are met, the application falls within SCI for Web scope. This technology-agnostic approach ensures the specification remains relevant as interaction
+paradigms evolve, without requiring constant redefinition. The focus on delivery mechanism and rendering context, rather than specific input/output modalities, provides
+stability across technological change.
+
+Platform-independence principle: The scope intentionally avoids tying definitions to current interaction patterns (keyboard/mouse/touch) or display characteristics
+(rectangular screens). This future-proofs the specification for emerging interfaces while maintaining clear classification criteria.

--- a/sci-web/README.md
+++ b/sci-web/README.md
@@ -1,0 +1,37 @@
+# Software Carbon Intensity (SCI) for Web (DRAFT SNAPSHOT)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GSF Project](https://img.shields.io/badge/GSF-Standards_Project-brightgreen)](https://greensoftware.foundation)
+
+> **A specification addressing the challenges of measuring website carbon emissions**
+
+Created and managed by the [Software Standards Working Group](https://github.com/Green-Software-Foundation/software-standards-wg) in the [Green Software Foundation](https://greensoftware.foundation).
+
+## Scope
+
+The purpose of this proposed specification is to assist web practitioners and developers, designers, architects, and decision-makers in understanding and reducing the carbon footprint of web applications. By making informed choices about architecture, performance optimization, and deployment strategies, practitioners can minimize emissions while maintaining user experience.
+
+We will develop a methodology for calculating the carbon emissions rate (SCI score) of web applications, providing standardized functional units and clear boundaries between web applications and other domains (APIs, SaaS, AdTech). This specification aims to provide a reliable, consistent, and comparable measure that practitioners can use to set targets and track progress in reducing carbon emissions across the entire web stack from client devices through networking to server infrastructure.
+
+## Appointments
+
+The project is led by:
+* [Chris Adams (Green Web Foundation)](https://github.com/mrchrisadams)
+
+## Status
+
+> **This is a proposal Standard and has not been approved or adopted by the Green Software Foundation. This pre-draft may not be relied upon for any purpose other than review of the current state of development.**
+
+This project is being initiated through a Member Assembly starting September 8, 2025, with application deadline September 5, 2025 [[project page](https://directory.greensoftware.foundation/projects/software-carbon-intensity-for-web/)].
+
+## Copyright
+
+Standard WG projects are copyrighted under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+## License
+
+Software Standard WG projects are licensed under the MIT License - see the LICENSE file for details.
+
+## Patent
+
+Software Standard WG projects operate under the W3C Patent Mode.

--- a/sci-web/REPORT.md
+++ b/sci-web/REPORT.md
@@ -1,0 +1,585 @@
+# SCI for Web - Assembly Report (DRAFT SNAPSHOT)git 
+
+**Status**: Draft Report from Assembly Process  
+**Version**: 1.0  
+**Date**: [06-01-26]  
+
+---
+
+## Executive Summary
+
+This document was created in Autumn 2025 using and AI orchestrated assembly process. Participants answered an initial set of questions by email, all of which were synthesised and used by an LLM to generate candidate content for each of the numbered sections in this document. The candidate content was then reviewed by the participants. After each round of review, a new candidate entry was generated, leading to a final round of review where participants ENDORSED, CONSENTED or OBJECTED to merging the proposed content into the draft. When there were no objections, the content was merged by the project chair. There were 14 participants in total, but the maximum number of active participants per round was 7. This document details the requirements for the SCI for Web specification. The actuial specification will be created in Q1 2026 according to this design document.
+
+---
+
+## 1. Scope Definition
+
+The SCI for Web specification applies to software applications that deliver functional value to human users primarily through browser-based interfaces accessed via HTTP/HTTPS protocols. A web application is characterized by three essential criteria: (1) content and functionality delivered over HTTP/HTTPS protocols, (2) rendering and execution occurring primarily within web browser environments or equivalent web rendering engines, and (3) interfaces designed for direct human interaction and consumption rather than exclusively machine-to-machine communication.
+
+The scope encompasses the full spectrum of browser-based applications regardless of architectural sophistication, including static content websites, dynamic platforms, single-page applications (SPAs), server-side rendered applications, e-commerce systems, media streaming services, and real-time collaborative tools. The distinguishing principle is browser-mediated human interaction: if users primarily access functionality through web browsers to accomplish tasks or consume content, the application falls within scope. This definition is intentionally platform-independent and technology-agnostic, focusing on delivery mechanism and user interaction patterns rather than specific implementation technologies.
+
+API-driven services require additional classification based on their primary access pattern. Pure machine-to-machine APIs serving only programmatic clients are out of scope and should use the base SCI methodology. However, APIs accessed primarily through browser-based interfaces—such as those with interactive documentation as the primary usage method or those coupled with browser-based management dashboards—fall within scope when the browser interface represents the primary human interaction mode. The determining factor is whether human users consume the service's value through browser rendering, not whether HTTP protocols are involved.
+
+---
+
+## 2. Target Personas
+
+
+The SCI for Web specification is designed for **technical practitioners who create and optimize browser-mediated web applications**, spanning both server-side infrastructure and client-side implementation. Because the agreed scope defines web applications through "browser-mediated human interaction via HTTP/HTTPS," the specification must serve personas who control energy consumption across the entire delivery chain—from servers generating responses to browsers rendering content for human users.
+
+### **Frontend Developers and Design Practitioners**
+
+These practitioners control the code, assets, and experiences delivered to browsers, directly affecting energy consumed on end-user devices during browser-mediated interactions. This includes:
+
+- **Frontend developers**: JavaScript bundle size and optimization, CSS efficiency, framework selection for client-side execution, third-party script integration, rendering performance, asset optimization (images, fonts, videos), progressive enhancement strategies, and client-side caching
+- **UX/UI designers**: Interface design decisions affecting resource consumption (infinite scroll vs. pagination, video backgrounds vs. static images, auto-playing media), interaction patterns determining data transfer frequency, content structure and information architecture
+- **Content designers**: Content strategy affecting page weight, media selection and optimization requirements, structured content delivery
+
+**What they control**: Client-side code efficiency, browser rendering performance, third-party client-side dependencies, asset delivery and optimization, user interaction patterns, content weight and structure, design decisions with 10x+ energy impact potential
+
+**What they don't control**: Server-side infrastructure location, database architecture, hosting provider selection, network infrastructure between datacenter and user, end-user device hardware specifications
+
+### **Backend and Infrastructure Engineers**
+
+These practitioners control server-side systems that generate and deliver content to browsers, affecting operational emissions from datacenters and infrastructure. This includes:
+
+- **Backend developers**: Server-side code efficiency, API design and optimization, database query performance, caching strategies, session management
+- **Infrastructure and systems engineers**: Cloud provider and geographic hosting location selection, server capacity planning and right-sizing, resource utilization policies, infrastructure architecture (static vs. dynamic provisioning), build and deployment pipeline efficiency (CI/CD, testing, artifact storage)
+- **Platform and DevOps engineers**: CDN configuration and edge caching, architectural patterns affecting server/client computation distribution (server-side rendering, static site generation, hybrid approaches), monitoring and observability systems, performance optimization tooling
+
+**What they control**: Server-side compute and storage resources, database efficiency and architecture, geographic hosting location and carbon intensity exposure, infrastructure capacity relative to actual traffic, deployment and build processes, caching at server and CDN levels, API efficiency
+
+**What they don't control**: End-user device choices, browser vendor implementations, client-side third-party script behavior (though can control whether to include them), market-based carbon offsets (excluded from SCI methodology)
+
+### **Product Owners and Technical Managers**
+
+These practitioners translate organizational goals into technical requirements and manage trade-offs between features, performance, and sustainability. This includes:
+
+- **Product owners and managers**: Feature prioritization and lifecycle management ("gardening"—pruning unnecessary features), performance budget setting, sustainability target definition, trade-off decisions between functionality and efficiency
+- **Technical leads and architects**: Architectural decision-making authority, technology selection across the stack, team capacity allocation for optimization work, supplier and third-party service selection criteria, non-functional requirements including performance and sustainability
+
+**What they control**: Which features get built and maintained, performance and sustainability budgets, team time allocation for optimization, supplier selection based on sustainability criteria, architectural standards and patterns
+
+**What they don't control**: Day-to-day implementation details, supplier internal implementations (though can switch suppliers), end-user behavior and device choices, industry-wide standards (though can advocate)
+
+### **Rationale: Connection to Scope**
+
+The agreed scope defines web applications as "browser-mediated human interaction" where "rendering and execution occur primarily within web browser environments." This explicitly requires measuring both server-side energy (generating responses) and client-side energy (rendering for human interaction). Frontend practitioners who control browser-delivered experiences are therefore equally essential to backend practitioners who control server infrastructure. Product roles provide the decision-making authority to prioritize sustainability work and set performance budgets that enable technical implementation.
+
+### **Critical Inclusion: Third-Party Dependencies and Transparency**
+
+Modern web applications depend extensively on third-party services for functionality (analytics, advertising, authentication, payments, CDNs, hosting). These dependencies consume energy on both servers and client devices. **Third-party services must be included within the SCI for Web boundary** to incentivize measurement, monitoring, and improvement of their performance and energy efficiency, encouraging them to reduce their own carbon emissions. Measurement and monitoring also provides the necessary data to make informed decisions about when and whether to select third-party services over first-party implementations.
+
+When precise energy data from third-party suppliers is unavailable, practitioners shall use industry default values with explicit disclosure that estimates were used. This approach balances comprehensiveness with implementation feasibility while creating market pressure for suppliers to provide transparency.
+
+**Supplier influence mechanism**: While practitioners cannot directly control third-party implementations, they exercise influence through vendor selection, contractual requirements for emissions transparency, and the collective market signal that sustainability performance affects purchasing decisions.
+
+### **Acknowledged but Not Primary Targets**
+
+**Suppliers and third-party service providers**: While their implementations significantly impact web application carbon footprint, they are users of this specification rather than its primary audience. The specification enables practitioners to pressure suppliers for transparency and better performance through informed vendor selection.
+
+**Standards bodies and regulatory authorities**: These entities set the broader context but are not the specification's implementation audience. The specification should align with existing standards (parent SCI methodology, accessibility guidelines) and support regulatory compliance without targeting these bodies as primary users.
+
+**End users and consumers**: These individuals have limited agency based on choices made by practitioners. User-facing interventions (sustainable mode toggles, carbon-aware delivery options) depend on practitioner implementation and are better addressed through choice architecture design than direct user targeting.
+
+---
+
+## 3. Implementation Practices and Incentives
+
+
+This section defines the specific practices that SCI for Web should encourage or discourage in teams who measure and optimize web applications. These implementation practices guide design decisions throughout the specification, ensuring that measurement drives genuine carbon reduction rather than metric optimization.
+
+**Implementation Note**: While this section describes comprehensive practices across all system components, teams may adopt SCI for Web incrementally. Starting with measurable components (client-side and server-side infrastructure under direct control) and progressively expanding scope to include network transfer and third-party services is an acceptable path to comprehensive measurement. However, disclosed methodology must clearly identify which components are measured versus estimated versus excluded to maintain transparency and prevent gaming.
+
+**Note on Principles vs. Prescription**: The practices described below represent principles and patterns that reduce energy consumption. They are not prescriptive engineering requirements. Teams should evaluate these principles within their specific context and implement them using approaches appropriate to their architecture, constraints, and objectives.
+
+## Encouraged Practices
+
+### For Frontend Developers and Design Practitioners
+
+**Energy reduction outcomes targeted**: Reduce data transfer, reduce page weight, reduce client-side energy consumption, extend end-user device lifespan, reduce CPU/GPU utilization during rendering.
+
+**Energy reduction practices to encourage:**
+
+- **Optimize asset delivery**: Reduce bundle sizes, compress assets appropriately (images, videos, PDFs, audio files, and other media), eliminate unused CSS and JavaScript, implement code splitting, lazy-load non-critical resources
+- **Choose efficient rendering approaches**: Use progressive enhancement, implement server-side rendering or static generation where appropriate, minimize client-side computation for tasks that could run more efficiently on servers
+- **Design for efficiency**: Favor text over video or decorative image backgrounds, implement pagination over infinite scroll where appropriate, avoid auto-playing media, optimize animation performance, design effective user workflows that minimize unnecessary interactions
+- **Reduce third-party dependencies**: Minimize analytics scripts, advertising trackers, and external fonts; evaluate whether each third-party service provides sufficient value for its energy cost
+- **Optimize for diverse devices**: Test on low-end devices, implement responsive images, ensure experiences work efficiently across device capabilities
+- **Inform users**: Provide transparency about the environmental impact of using or overusing certain features, such as reverse logistics in e-commerce or continuous rendering of intensive visual assets
+
+**How these practices reduce energy:** Client-side optimizations directly reduce energy consumed on end-user devices (operational) and can extend device lifespan (embodied). Smaller data transfers reduce network energy. Efficient rendering reduces CPU/GPU utilization and battery drain. User transparency enables informed decision-making about feature usage.
+
+### For Backend and Infrastructure Engineers
+
+**Energy reduction outcomes targeted**: Minimize server-side resource usage, reduce datacenter electricity consumption, reduce CPU/memory/storage utilization, reduce network transmission distance and carbon intensity exposure.
+
+**Energy reduction practices to encourage:**
+
+- **Right-size infrastructure**: Match server capacity to actual load, avoid over-provisioning, implement auto-scaling that responds to real demand, decommission unused services, optimize underlying infrastructure choices such as VM instance types and image sizes
+- **Optimize database and API efficiency**: Design efficient database schemas, write efficient queries, implement appropriate indexing, reduce unnecessary data fetching, cache effectively, eliminate N+1 query patterns
+- **Choose efficient hosting**: Select hosting providers and regions based on carbon intensity and renewable energy availability, use edge computing to serve users from geographically closer locations
+- **Architectural efficiency**: Implement effective caching strategies (CDN, server-side, database), use content delivery networks appropriately, select efficient technology stacks
+- **Measure and monitor resource utilization**: Track actual CPU, memory, and storage usage; identify and eliminate wasteful operations; implement benchmarking during development and production phases
+
+**How these practices reduce energy:** Server optimizations directly reduce datacenter electricity consumption. Right-sizing reduces both operational energy and embodied emissions from idle hardware. Geographic hosting choices reduce both transmission distance and exposure to carbon-intensive grids. Benchmarking during development catches inefficiencies before production deployment.
+
+### For Product Owners and Technical Managers
+
+**Energy reduction outcomes targeted**: Prevent feature bloat that increases page weight and server load, establish performance constraints that limit energy consumption, incentivize vendor efficiency improvements through market pressure.
+
+**Energy reduction practices to encourage:**
+
+- **Practice "feature gardening"**: Regularly audit and remove low-value features that consume resources, resist feature bloat, prioritize quality over quantity
+- **Set performance and environmental budgets**: Establish and enforce limits on page weight, JavaScript execution time, and API response times that implicitly constrain energy consumption; define environmental budgets that track sustainability KPIs such as energy use, waste, and CO2 emissions thresholds in alignment with frameworks like GRI
+- **Make informed vendor decisions**: Select third-party services based on their efficiency and carbon transparency, require emissions data from vendors, switch to more efficient alternatives when available
+- **Allocate optimization time**: Provide team capacity for performance and efficiency work, treat optimization as ongoing maintenance rather than one-time effort
+- **Balance functionality with efficiency**: Make conscious trade-offs between feature richness and resource consumption, question whether new features justify their carbon cost
+- **Make carbon efficiency a quality attribute**: Implement non-functional requirements for carbon emissions, measure them, and use them as quality gates in development processes
+- **Prefer "always-available" over "always-on"**: Design systems so that resource-intensive features (like intensive rendering, data export, or batch processing) can be scheduled during low-carbon periods or rate-limited rather than running continuously at any time
+
+**How these practices reduce energy:** Product and management decisions determine what gets built and maintained. Removing unused features eliminates ongoing server costs and client-side execution. Performance and environmental budgets prevent gradual efficiency degradation. Vendor transparency requirements create market incentives for supplier optimization. Carbon-aware scheduling reduces emissions by timing computation to periods of lower grid carbon intensity.
+
+### For Third-Party Service Providers and Hosting Suppliers
+
+**Energy reduction outcomes targeted**: Reduce energy consumption per operation across all customer implementations, enable informed vendor selection through transparency, reduce grid carbon intensity through renewable energy procurement.
+
+**Energy reduction practices to encourage:**
+
+- **Provide transparency**: Publish energy consumption and carbon emissions data for services, offer APIs for customers to access real-time or historical emissions data
+- **Optimize implementations**: Invest in efficiency improvements that reduce energy per operation, implement efficient caching and content delivery
+- **Support customer measurement**: Provide detailed metrics on resource consumption, enable customers to attribute emissions accurately
+- **Procure renewable energy**: Procure renewable energy wherever possible for all energy-consuming activities. For datacenters, select low-carbon hosting locations and invest in energy efficiency improvements
+
+**How these practices reduce energy:** Supplier optimizations cascade across all customers. Transparency enables informed vendor selection. Renewable energy procurement reduces carbon intensity exposure for all customer workloads.
+
+## Discouraged Practices
+
+### Energy Displacement Rather Than Reduction
+
+**Practice to discourage:** Shifting computation from measured locations to unmeasured locations to improve metrics without reducing total system energy.
+
+**Examples:**
+- Moving computation from servers to client devices through heavy JavaScript to reduce measured server energy while increasing unmeasured client energy
+- Outsourcing computation to third-party services to externalize emissions from first-party measurements
+- Increasing build-time computation to reduce runtime computation (if development lifecycle is unmeasured)
+
+**Why this matters:** Displacement makes metrics look better while total system energy stays the same or increases. This is measurement gaming, not carbon reduction.
+
+**Design implication:** SCI for Web must measure comprehensively across servers, networks, third-party services, and end-user devices to close displacement pathways.
+
+### Quality Degradation as "Optimization"
+
+**Practice to discourage:** Reducing functionality, accessibility, security, privacy, or user experience to improve energy metrics.
+
+**Examples:**
+- Reducing image quality below acceptable thresholds to decrease data transfer
+- Removing accessibility, security, or privacy features to reduce the website payload
+- Limiting essential functionality to reduce computation
+- Degrading user experience (e.g., removing helpful features) to improve scores
+
+**Why this matters:** Measurements should incentivize delivering functionality efficiently, not delivering reduced functionality. Users accomplish the same tasks less efficiently or switch to less-efficient alternatives. Compromising accessibility, security, or privacy creates net harm that outweighs carbon benefits.
+
+**Design implication:** Functional units should measure energy per delivered functionality, not energy per technical operation. Multidimensional metrics capture quality-efficiency trade-offs.
+
+### Market-Based Measures Instead of Elimination
+
+**Practice to discourage:** Using carbon offsets, renewable energy certificates (RECs), or other market-based instruments to improve scores without reducing actual energy consumption.
+
+**Examples:**
+- Purchasing carbon offsets to neutralize emissions while maintaining inefficient operations
+- Buying RECs to claim "green" energy without reducing actual electricity use
+- Geographic arbitrage where applications claim low emissions by measuring only low-carbon regions while serving global users
+
+**Why this matters:** The parent SCI specification explicitly excludes market-based measures (see SPEC.md sections on Exclusions and Market-based Measures). The goal is eliminating emissions through efficiency, not compensating for inefficiency through financial instruments. As stated in the SCI specification: "Reducing an SCI score is only possible through the elimination of emissions."
+
+**Design implication:** SCI for Web measures energy consumption and carbon intensity based on actual infrastructure location and operation, without adjustments for offsets or certificates. Carbon intensity calculations use location-based grid intensity, excluding market-based measures as defined in the parent specification.
+
+### Measurement Gaming and Boundary Manipulation
+
+**Practice to discourage:** Optimizing measurement boundaries and methodologies to improve scores without reducing actual emissions.
+
+**Examples:**
+- Selectively excluding high-emission components from measurement scope
+- Choosing functional units that make inefficient operations appear efficient
+- Reducing essential activities (testing, security updates) to improve operational metrics
+- Cherry-picking measurement timeframes to avoid high-load periods
+
+**Why this matters:** Gaming destroys measurement credibility and prevents comparability. Organizations compete on measurement skill rather than actual efficiency.
+
+**Design implication:** Mandatory comprehensive boundaries, disclosed methodologies, and consistent functional units prevent gaming while allowing legitimate architectural diversity.
+
+### Vanity Metrics and Proxy Optimization
+
+**Practice to discourage:** Optimizing proxy metrics that correlate weakly with actual energy consumption.
+
+**Examples:**
+- Optimizing page weight without considering how assets are used (e.g., reducing rarely-loaded resources while ignoring frequently-loaded ones)
+- Focusing on first contentful paint while ignoring total page energy consumption
+- Reducing server response time by pushing computation to client without measuring total system impact
+- Optimizing for synthetic benchmarks that don't reflect real user usage patterns
+
+**Why this matters:** Proxy optimization can increase actual energy while improving measured proxies. Focus on proxies diverts attention from genuine efficiency improvements.
+
+**Design implication:** Where possible, measure actual energy consumption rather than proxies. When proxies are necessary, validate correlation with real energy impact and use multiple dimensions.
+
+## Design Implications for SCI for Web
+
+These implementation goals inform specific design decisions:
+
+**Comprehensive measurement boundaries:** To discourage displacement, SCI for Web must measure energy across servers, networks, third-party services, and end-user devices. Excluding any major component creates a displacement pathway.
+
+**Functional units measuring delivered functionality:** To discourage quality degradation, functional units should capture delivered functionality (transactions, content consumed, tasks completed) rather than just technical operations (page views, API calls).
+
+**Mandatory disclosure of methodologies:** To prevent boundary gaming, organizations must disclose what they measured, how they measured it, and what they excluded. This enables peer comparison and identifies gaming attempts.
+
+**Operational serving focus:** To avoid perverse incentives in development practices (reduced testing, delayed security patches), measure operational serving efficiency separately from development lifecycle efficiency.
+
+**Exclusion of market-based measures:** Following the parent SCI specification, SCI for Web excludes offsets, RECs, and other market-based instruments, focusing measurement on actual energy elimination through the three sustainability actions defined in the parent specification: energy efficiency, hardware efficiency, and carbon awareness.
+
+**Tiered implementation with disclosed sophistication:** To encourage adoption while maintaining comprehensive boundaries, allow organizations to start with industry defaults and increase measurement sophistication over time, with mandatory disclosure of which tier methodology is used.
+
+**Inclusion of embodied emissions:** To account for hardware manufacturing impacts and incentivize longer device lifespan and better resource utilization, include embodied emissions allocated proportionally to usage time, following the calculation methodology specified in the parent SCI specification.
+
+**Third-party service transparency requirements:** To pressure vendors for efficiency improvements, require including third-party services with vendor-provided data where available or conservative proxy estimates where unavailable.
+
+The overarching principle: SCI for Web design decisions should make practices that genuinely reduce total system energy the same practices that improve measured scores. When measurement and reality align, teams optimize actual efficiency rather than metrics.
+
+
+---
+
+## 4. Evaluation Criteria
+
+# Section 4: Evaluation Criteria - Merged Consensus Proposal
+
+## Overview
+
+This section establishes evaluation criteria for SCI for Web that balance scientific rigor with practical adoptability. The criteria recognize that unused specifications serve no one, while measurements lacking credibility undermine sustainability efforts. Our evaluation framework prioritizes defensible accuracy where teams have direct control, workflow integration over exceptional effort, and transparent limitations over false precision.
+
+The fundamental tension: scientifically rigorous specifications that nobody implements versus imperfect but widely adopted measurements that actually reduce carbon. SCI for Web must navigate this trade-off by being accurate enough to drive meaningful behavior change while simple enough for widespread adoption.
+
+## 1. The Accuracy-Adoption Trade-off
+
+### Sufficient Accuracy for Behavior Change
+
+SCI for Web does not require laboratory-grade precision to drive meaningful behavior change, but accuracy must be real, not merely perceived. Measurements inform decisions with carbon and ethical implications, making actual accuracy critical even as we acknowledge that perfect precision is unattainable.
+
+**Accurate enough to be defensible**: Measurements should enable teams to make informed decisions about which approaches genuinely reduce carbon emissions. When comparing options or tracking changes over time (comparing version A to version B, or approach X to approach Y), teams need confidence that observed differences reflect reality. A measurement framework showing that one implementation approach has 20% higher energy consumption than another warrants investigation and drives optimization; a framework showing 50% variance for equivalent implementations creates confusion and mistrust.
+
+The acceptable variance range depends on what teams have direct control over:
+- **Directly measured components** (browser execution, server operations teams manage): measurements within 10-15% of actual consumption enable confident decision-making
+- **Well-modeled components** with substantial real-world data backing (network transfer, user device diversity): measurements within 15-20% are acceptable as a starting point, with expectation of improvement as datasets grow
+- **Components with limited data availability**: clearly labeled placeholders and estimates are acceptable when they are explicitly marked as such, based on best available data and reasonable assumptions, documented with clear methodology, and accompanied by a path to improvement
+
+**Proportional to control and influence**: Accuracy requirements should scale with the degree of direct control teams have:
+- High accuracy for directly controlled elements (browser rendering from code teams write, server operations they manage)
+- Moderate accuracy for indirectly influenced elements (user behavior patterns, caching effectiveness, third-party services where vendor selection is controlled)
+- Explicit acknowledgment of uncertainty for uncontrolled elements (network infrastructure beyond origin servers, diverse user device characteristics)
+
+This proportionality principle aligns with the parent SCI specification's emphasis on actionable measurements that drive the three sustainability actions: energy efficiency, hardware efficiency, and carbon awareness.
+
+**Grounded in measurable reality**: Where direct measurement is feasible, it should be the foundation. Where modeling is necessary, it should be backed by substantial datasets from real-world observations, not theoretical assumptions. This follows the parent SCI specification's guidance: "The SCI encourages calculation using granular real-world data" while allowing "data generated through modeling, using best estimates" when real-world data is unavailable.
+
+### Implementation Simplicity for Widespread Adoption
+
+The parent SCI specification establishes as a core characteristic that "The SCI is easy to implement" and that "anyone without much experience or training shall be able to follow the SCI specification instructions." SCI for Web must honor this principle while addressing web-specific complexity.
+
+**Workflow integration**: The specification should work within existing tools and platforms—content management systems, CI/CD pipelines, analytics tools, monitoring systems. If adoption requires new toolchains separate from normal development workflows, it faces immediate organizational resistance. This aligns with Section 3's identified behavioral incentive: teams will only adopt measurement that integrates naturally into their existing practices.
+
+**Automation and standardization**: Manual measurement invites inconsistency and abandonment. High degrees of automation lower entry barriers, making adoption possible across the diverse roles identified in Section 2 (frontend developers, DevOps engineers, product managers) without specialized sustainability training.
+
+**Clear boundaries and minimal disruption**: Teams should understand exactly what they're measuring, why it matters, and what actions they can take. The specification should define clear scope boundaries that map to team responsibilities and capabilities identified in the Target Personas section.
+
+**Progressive sophistication**: Teams at different capability levels and organizational contexts should be able to adopt SCI for Web appropriately. Entry-level adoption with simpler methodologies should be legitimate and valuable, with clear pathways to more comprehensive measurement as capabilities mature. (Note: specific maturity tier definitions belong in the formal specification, not this evaluation criteria section.)
+
+## 2. Trust and Transparency Requirements
+
+### Mandatory Disclosure
+
+Credibility requires transparency about methodology, data sources, and limitations. The parent SCI specification requires that teams "Disclose the SCI score, software boundary, and the calculation methodology." SCI for Web extends this principle to web-specific contexts.
+
+**Methodology and assumptions**: The calculation approach, models used, and assumptions made must be explicitly documented. When placeholders, estimates, or constants are used, they must be clearly identified as such with justification for the chosen values. This enables peer review and prevents hidden gaming.
+
+**Data provenance**: Sources of data—whether from direct measurement, third-party services, reference devices, or public databases—must be disclosed. The chain from raw data to final calculation should be traceable. This follows the parent specification's emphasis on encouraging "the use of granular data."
+
+**Measurement boundaries**: What is included and excluded from the measurement must be explicit, following the parent specification's software boundary guidance. If third-party services are excluded, state this. If measurements only apply to specific user journeys or geographic regions, say so. This prevents boundary gaming identified in Section 3 as a discouraged practice.
+
+**Limitations and uncertainty**: Where accuracy cannot be assured, acknowledge it. Where control is limited, make it visible. Uncertainty ranges should be disclosed rather than hidden behind false precision. A single unconvincing component presented with false precision can discredit the entire framework.
+
+**Quantification method disclosure**: Following the parent SCI specification's procedure, teams must disclose whether they used measurement (real-world data) or calculation (models) for each component, and with what level of sophistication. This transparency enables comparability and prevents gaming through selective methodology choices.
+
+### Optional but Valuable Disclosure
+
+Beyond minimum requirements, teams should be encouraged to share:
+- Comparative analyses showing changes over time (aligning with parent specification's baseline comparison guidance)
+- Context about organizational constraints that affected measurement choices
+- Lessons learned about what drove adoption or created barriers
+- Improvement plans for advancing measurement sophistication
+
+## 3. Threshold Criteria for Usefulness
+
+### Minimum Accuracy Thresholds
+
+For SCI for Web to be useful for driving the behavioral incentives identified in Section 3, it must meet minimum accuracy standards:
+
+**For directly controlled components**: Where teams have direct control and measurement access (browsers they test with, servers they operate), accuracy should support confident decision-making. Measurements showing that implementation A has 10-15% higher energy consumption than implementation B should reliably indicate a genuine efficiency difference worth investigating.
+
+**For modeled components with strong data backing**: Where direct measurement isn't feasible but substantial real-world data exists (network transfer, user device diversity), models should produce results within 15-20% of actual consumption. This level of accuracy is sufficient to identify major inefficiencies and track directional improvement.
+
+**For components without adequate data**: Rather than presenting false precision, these should be explicitly marked as placeholders or rough estimates with wide uncertainty ranges, excluded from initial scope with a clear path to inclusion, or included with documented estimation methodology and clear improvement roadmap.
+
+The key principle: measurements must be accurate enough that optimizing the measured score reliably leads to actual carbon reduction, not merely metric improvement. This prevents the "vanity metrics and proxy optimization" practice discouraged in Section 3.
+
+### Maximum Complexity Boundaries
+
+Complexity kills adoption. The parent SCI specification emphasizes that calculation "shall be possible without incurring any cost, for instance, for data, services, or tooling." SCI for Web should respect these boundaries:
+
+**Parameter count**: The number of variables teams must track should be gatherable through normal development workflows. If gathering data requires dedicated data collection efforts beyond what teams already do for performance monitoring, expect resistance. This varies by organizational capability—what's feasible for a large enterprise may overwhelm a small team.
+
+**Calculation complexity**: The calculation should be explainable to a skeptical technical manager in under five minutes. The parent SCI specification's formula `SCI = (O + M) per R` is elegant; web-specific extensions should maintain this conceptual simplicity even when operational details are more involved. If it requires specialized knowledge to understand, it will be rejected when scrutinized.
+
+**Tool requirements**: Implementation should work with widely available, preferably open source tooling. Dependence on proprietary or expensive tools creates adoption barriers that contradict the parent specification's "easy to implement" principle and "no cost" requirement.
+
+**Progressive entry barriers**: Teams new to sustainability measurement should be able to start with automated tooling and industry defaults. As they mature, they can invest in more sophisticated measurement. But the entry barrier must be low enough that starting is feasible for the frontend developers, backend engineers, and product managers identified in Section 2.
+
+## 4. Gaming Prevention Principles
+
+Section 3 identified several discouraged practices: energy displacement, quality degradation, boundary manipulation, and vanity metrics. SCI for Web must be designed to prevent these forms of gaming while avoiding paralysis through over-complexity.
+
+### Design Against Gaming
+
+**Measure outcomes, not proxies**: Where possible, measure actual energy consumption rather than proxy metrics that can be optimized without real impact. This aligns with the parent SCI specification's focus on quantifying actual carbon emissions (operational plus embodied) rather than indirect proxies.
+
+**Comprehensive boundaries**: The parent specification states "The calculation of SCI shall include all supporting infrastructure and systems that significantly contribute to the software's operation." For web applications, this means measuring energy across servers, networks, third-party services, and end-user devices. Excluding major components creates displacement pathways where teams shift computation from measured to unmeasured locations without reducing total energy.
+
+**Functional units measuring delivered value**: To discourage quality degradation, functional units should capture delivered functionality (user tasks completed, transactions processed, content consumed) rather than just technical operations (page views, API calls). This follows the parent specification's guidance that R should describe "how the application scales" in terms meaningful to its purpose.
+
+**Avoid perverse incentives**: Ensure that optimizing for the SCI score aligns with genuine sustainability improvements. If the specification can be gamed by degrading user experience, shifting emissions elsewhere, or reducing essential quality attributes (accessibility, security, privacy), it will be gamed. Section 3 explicitly identifies these as discouraged practices.
+
+### Balanced Perspective on Gaming Risk
+
+Gaming is a real concern but should not cause design paralysis. Gaming requires effort, and for most teams, actually improving efficiency is easier than developing sophisticated gaming strategies. However, organizations facing performance pressure without strong sustainability culture may seek ways to show progress without actual improvement.
+
+The solution is not paralysis through over-complexity, but transparency and clear guardrails:
+- **Low-friction entry**: Make it easy to start measuring (reduces incentive to game by making genuine measurement easier than gaming)
+- **Mandatory disclosure**: Make methodology, boundaries, and quantification methods visible (makes gaming detectable)
+- **Clear improvement pathways**: Provide structured advancement to higher sophistication (channels competitive energy toward better measurement rather than gaming)
+- **Reputational accountability**: Market scrutiny and stakeholder pressure create natural disincentives for visible gaming
+
+### Design for Adversarial Defense
+
+The specification must withstand scrutiny from people motivated to reject it—technical skeptics, budget guardians, and organizational resistance to sustainability investment.
+
+**Defensible data foundation**: Every significant component should be traceable to direct measurements or well-documented datasets. Speculative models undermine credibility for the entire specification. As one participant noted, "In subjects where there are wider ethical or physical impacts, the actuality of those numbers moving is critical."
+
+**Scope alignment with control**: Teams should only be accountable for elements they can reasonably control or influence, as defined in Section 2's persona descriptions. Measuring things beyond their control creates grounds for rejection: "Why should I be measured on something I can't affect?"
+
+**Proportionate response to uncertainty**: Where uncertainty exists, acknowledge it rather than presenting false precision. As the parent specification acknowledges, access to data "might not always be available" and "modeling, using best estimates" is acceptable. Honest acknowledgment of uncertainty builds more trust than false precision.
+
+## 5. Success Indicators
+
+We will know SCI for Web succeeds when it drives the behavioral incentives identified in Section 3 and serves the target personas identified in Section 2.
+
+### Adoption Signals
+
+**Cross-organizational adoption**: Implementation occurs across different organizational contexts (SaaS providers, e-commerce platforms, media companies, small startups, large enterprises) without requiring extensive customization. This demonstrates that the specification serves diverse environments while maintaining consistency.
+
+**Multi-role engagement**: The diverse roles identified in Section 2 (frontend developers, backend engineers, DevOps practitioners, product managers) can integrate SCI for Web into their workflows without specialized training for entry-level adoption.
+
+**Sustained usage**: Teams continue measuring beyond initial implementation, indicating that the effort-to-value ratio is favorable. Measurement becomes part of normal development practice rather than a one-time compliance exercise.
+
+**Voluntary adoption**: Organizations adopt SCI for Web before regulatory or reputational pressure makes it mandatory, suggesting genuine perceived value. This aligns with the parent specification's goal of helping "users and developers make informed choices."
+
+**Progression over time**: Organizations advance from simpler to more sophisticated measurement approaches over time, demonstrating deepening commitment and capability.
+
+**Industry recognition**: SCI for Web becomes the default reference in articles, conferences, and discussions about web sustainability. Industry leaders publicly adopt and advocate for the specification.
+
+**Competitive and market pressure**: Organizations adopt SCI for Web because competitors are doing it, and not measuring becomes a competitive disadvantage. This market dynamic accelerates adoption without requiring regulatory mandates.
+
+**Regulatory incorporation**: Government sustainability requirements and industry standards reference SCI for Web as an acceptable methodology, validating the specification's credibility.
+
+### Impact Signals
+
+**Behavioral change evidence**: Observable changes in development practices—optimization decisions, architectural choices, vendor selection, infrastructure planning—driven by SCI for Web insights. This is the ultimate success metric: does measurement actually change what teams build and how they build it?
+
+**Credibility in skeptical contexts**: The specification withstands adversarial scrutiny from technically sophisticated skeptics, budget guardians, and auditors. When challenged, the measurement methodology is defensible with clear data provenance and reasonable assumptions.
+
+**Improvement over time**: As teams iterate, their SCI scores improve, indicating that measurement is driving meaningful efficiency gains. This follows the parent specification's baseline comparison guidance: teams should be able to demonstrate that actions taken reduced their SCI score.
+
+**Alignment with identified behavioral incentives**: The practices identified in Section 3 as encouraged (efficiency improvements, architectural optimization, responsible vendor selection, quality-preserving carbon reduction) are demonstrably incentivized by optimizing SCI for Web scores. Conversely, discouraged practices (energy displacement, quality degradation, boundary gaming) don't improve scores or are made visible through disclosure requirements.
+
+**Prioritization capability**: Organizations use SCI for Web measurements to build Marginal Abatement Cost (MAC) curves that help prioritize sustainability investments—identifying high-impact, low-effort improvements before tackling expensive, complex optimizations. This demonstrates that the measurement framework enables practical prioritization of the three sustainability actions defined in the parent specification: energy efficiency, hardware efficiency, and carbon awareness.
+
+**Carbon reduction at scale**: Aggregate carbon reduction across organizations implementing SCI for Web demonstrates real environmental impact. The parent specification states its purpose is "to help users and developers make informed choices... that will ultimately minimize carbon emissions." Success means actual emissions reduction, not just measurement sophistication.
+
+**Ecosystem emergence**: Tools, services, training, and consultancies built around SCI for Web create self-sustaining momentum and reduce implementation barriers over time. This ecosystem development indicates that the specification hit the right balance between rigor and adoptability.
+
+## 6. Implementation Feasibility Boundaries
+
+### What We Can Reasonably Expect
+
+The parent SCI specification acknowledges varying capabilities: "While teams should consider investing more time or money in calculating their SCI number to increase its accuracy," basic calculation "shall be possible without incurring any cost."
+
+**Universal expectations** (feasible for all organizations):
+- Automated measurement using open source tooling and reference devices for components under direct control
+- Integration into CI/CD pipelines for tracking changes over time
+- Documentation of methodology, boundaries, and limitations
+- Measurement of directly controlled components (browser environments they test, servers they operate)
+
+**Context-dependent expectations** (varies by organizational capability):
+- Mix of direct measurement and validated modeling for broader scope
+- Investment in measurement infrastructure proportional to organizational size and sustainability commitment
+- Expanded scope including network transfer and third-party estimation
+- Statistical validation and real-world user data integration
+
+This recognizes that the frontend developers at small startups and the sustainability engineers at large enterprises (both identified in Section 2) have vastly different resources while both needing to adopt SCI for Web.
+
+### What Is Too Complex to Expect Broadly
+
+**Universal real-time monitoring**: Continuous measurement of every component creates infrastructure and complexity burdens that most teams cannot sustain. This exceeds the parent specification's "easy to implement" principle.
+
+**Perfect accuracy across all components**: The parent specification acknowledges that "access to the data needed for higher resolution calculations might not always be available." Some components (diverse user devices, network infrastructure beyond origin servers, embodied emissions of user hardware) cannot be measured with high accuracy by most teams.
+
+**Custom hardware instrumentation**: Expecting teams to deploy specialized measurement hardware is unrealistic for widespread adoption and contradicts the "no cost" principle.
+
+**One-size-fits-all requirements**: Different organizational contexts face different constraints. A measurement methodology rigid enough to force uniformity will fail to achieve adoption across the diverse personas and contexts identified in Section 2.
+
+### Third-Party Service Disclosure
+
+Section 3 identifies third-party transparency as an encouraged practice for suppliers. Major third-party services (CDNs, analytics platforms, advertising networks, API services) should disclose carbon impact of their services. While full third-party measurement may not be feasible for most organizations, SCI for Web should create market pressure for this disclosure:
+
+- Entry-level adoption: Document third-party services used and their handling in methodology disclosure
+- Intermediate adoption: Estimate third-party impact using documented methodology (data transfer, API calls, etc.)
+- Advanced adoption: Incorporate third-party disclosure data where available, use validated estimation where not
+
+This approach balances comprehensiveness with implementation feasibility while creating market pressure for suppliers to provide transparency.
+
+### Embodied Emissions Considerations
+
+The parent SCI specification requires including embodied emissions: "An estimate of all the embodied emissions for the hardware used within the software boundary shall be included." For web applications, this is particularly challenging where user devices are entirely outside the application provider's control.
+
+**Feasible approach**: Include embodied emissions for infrastructure under direct control (owned servers, owned network equipment) using the parent specification's time-share and resource-share methodology. For user devices, use documented estimation approaches based on reasonable device lifecycle assumptions and average embodied emissions data, with clear disclosure of the estimation methodology used.
+
+This balances the parent specification's requirement with practical limitations while maintaining transparency.
+
+## 7. Connection to Behavioral Incentives
+
+The evaluation criteria directly enable the behavioral incentives identified in Section 3:
+
+**Efficiency improvements made visible**: By providing accurate measurement of directly controlled components, SCI for Web makes efficiency improvements visible and attributable, creating clear incentives for the optimization practices identified in Section 3 (asset optimization, code efficiency, database optimization, infrastructure right-sizing).
+
+**Architectural choices informed by evidence**: When architectural choices (caching strategies, rendering approaches, server/client computation distribution) show measurable impacts on SCI scores, teams gain concrete evidence to justify architectural investments identified in Section 3.
+
+**Vendor selection enabled**: Where third-party services can be measured or compared through disclosed data, SCI for Web enables the evidence-based vendor selection identified in Section 3 as an encouraged practice.
+
+**Quality preserved**: By measuring actual energy consumption for delivered functionality rather than crude proxies, SCI for Web rewards genuine efficiency rather than quality degradation masquerading as sustainability—explicitly preventing the discouraged practice identified in Section 3.
+
+**Prioritization enabled**: SCI for Web enables organizations to identify high-impact, low-effort improvements through Marginal Abatement Cost curve analysis, ensuring resources are directed efficiently toward the three sustainability actions defined in the parent specification.
+
+**Gaming prevented or exposed**: Through comprehensive boundaries and mandatory disclosure, the discouraged practices identified in Section 3 (energy displacement, boundary manipulation, vanity metrics) are either prevented by design or made visible through disclosure requirements.
+
+## 8. Key Principles Summary
+
+**Defensibility over comprehensiveness**: Better to measure a narrow scope accurately than claim broad coverage without credible data. Entry-level adoption measuring only directly controlled components is legitimately useful even with limited scope.
+
+**Integration over addition**: Success requires embedding into existing workflows, not adding new exceptional processes. This serves the diverse personas identified in Section 2.
+
+**Transparency about limitations**: False precision destroys credibility; honest acknowledgment of uncertainty builds trust. Mandatory disclosure prevents gaming and enables peer review.
+
+**Proportionate accountability**: Hold teams accountable only for what they can reasonably control and measure, as defined in Section 2's persona descriptions. This makes rejection less likely and adoption more feasible.
+
+**Adversarial resilience**: Design for skeptical scrutiny from technically sophisticated critics, budget guardians, and organizational resistance. Defensible data and transparent methodology withstand challenge.
+
+**Tangible value demonstration**: Show concrete benefits—cost savings, performance improvements, competitive advantage, prioritization capability—not just sustainability scores. This aligns incentives for adoption.
+
+**Progressive sophistication**: Enable entry at appropriate capability level while providing clear advancement pathways. All levels of sophistication are legitimate when honestly disclosed.
+
+**Real accuracy, not perceived**: Measurements must be real because sustainability has ethical and physical implications. As one participant emphasized, "the actuality of those numbers moving is critical."
+
+**Estimation with guardrails**: Estimation and placeholders are acceptable when clearly labeled, documented, and accompanied by improvement pathways. This follows the parent specification's allowance for modeling while maintaining transparency.
+
+**Market pressure for improvement**: Transparency, competitive pressure, and stakeholder expectations naturally encourage sophistication advancement and third-party disclosure over time.
+
+**Ecosystem enablement**: Lower entry barriers and clear standards enable ecosystem development (tools, services, training) that accelerates adoption and reduces future implementation costs.
+
+**Alignment with parent SCI specification**: All evaluation criteria honor the parent specification's core characteristics (sensitivity to sustainability actions, systems-impact view, ease of implementation, encouragement of granular data) and requirements (comprehensive boundaries, disclosure, exclusion of market-based measures).
+
+---
+
+## Conformance to Parent SCI Specification
+
+This evaluation criteria section aligns with the parent SCI specification's core characteristics and requirements:
+
+**Sensitivity to sustainability actions**: The accuracy thresholds and measurement approaches are designed to be sensitive to the three sustainability actions defined in the parent specification—energy efficiency, hardware efficiency, and carbon awareness. Actions that reduce energy consumption, improve hardware utilization, or leverage lower-carbon energy will improve SCI for Web scores.
+
+**Systems-impact view**: The emphasis on comprehensive boundaries and prevention of energy displacement ensures that SCI for Web takes the systems view required by the parent specification, preventing "local-level optimizations that might lead to negative downstream impacts."
+
+**Easy to implement**: The progressive sophistication approach and emphasis on workflow integration honor the parent specification's requirement that "anyone without much experience or training shall be able to follow the SCI specification instructions" and that calculation be "possible without incurring any cost."
+
+**Encouragement of granular data**: The accuracy thresholds and disclosure requirements encourage teams to use the most granular data available while allowing modeling when real-world data is unavailable, exactly as the parent specification prescribes.
+
+**Exclusion of market-based measures**: Gaming prevention explicitly prevents using offsets, RECs, or other market-based instruments to reduce scores, following the parent specification's exclusions section.
+
+**Disclosure requirements**: The mandatory transparency requirements extend the parent specification's procedure step 5: "Report: Disclose the SCI score, software boundary, and the calculation methodology."
+
+The evaluation criteria ensure that SCI for Web extends the parent specification to web-specific contexts while honoring all core principles and requirements.
+
+
+---
+
+## 9. Comparative Analysis
+
+
+This section evaluates existing frameworks and tools against the evaluation criteria established in Section 4. The assessment aims to understand current capabilities, identify gaps, and inform the development of SCI for Web specifications.
+
+Before presenting comparative scores, it's essential to understand what is being compared. These frameworks serve different purposes and exist at different maturity levels:
+
+| Framework | Type | Maturity Level | Primary Purpose | Last Major Update | Links |
+|-----------|------|----------------|-----------------|-------------------|-------|
+| **SWDM (Sustainable Web Design Model)** | Methodology / estimation model | Mature, stable | Carbon estimation methodology for web transfers using system-wide allocation | 2024 | [SWD Methodology](https://sustainablewebdesign.org/calculating-digital-emissions/) |
+| **CO2.js** | Open-source library (SWDM implementation) | Mature, stable | Programmatic implementation of SWDM for carbon estimation | 2024 (v13) | [CO2.js](https://github.com/thegreenwebfoundation/co2.js) |
+| **Website Carbon Calculator** | Web application (SWDM-based) | Mature, stable | Public awareness and single-page estimation using SWDM | 2023 | [Website Carbon](https://www.websitecarbon.com/) |
+| **Ecograder** | Automated testing tool (SWDM + Lighthouse) | Active development | Multi-dimensional web sustainability assessment using SWDM for carbon | 2024 (beta with WSG integration) | [Ecograder](https://ecograder.com/), [Beta](https://beta.ecograder.com/) |
+| **W3C WSG** | Living standard (W3C specification) | Active development | Comprehensive sustainability guidelines for web | Ongoing (2024) | [W3C Web Sustainability Guidelines](https://www.w3.org/TR/web-sustainability-guidelines/) |
+| **Parent SCI** | Technical specification (GSF standard) | Established, refinement phase | Generic software carbon intensity measurement framework | 2022 (v1.0) | [SCI Specification](https://sci.greensoftware.foundation/) |
+| **Cardamon** | Web application (SCI-compatible) | Active development | SCI-compatible web carbon measurement with ground truth validation | 2024 | [Cardamon App](https://web.cardamon.io), [Paper](https://cardamon.io/sci), [Core](https://github.com/Root-Branch/cardamon-core) |
+| **Green Metrics Tool** | Testing/CI platform (SCI implementation) | Mature, growing | SCI score calculation for web apps using observed hardware data | 2024 | [Green Metrics Tool](https://docs.green-coding.io), [SCI Docs](https://docs.green-coding.io/docs/measuring/carbon/sci/) |
+| **Greenspector** | Testing platform | Established (France) | Carbon intensity measurement linked to functional units, CI/CD integration | 2024 | [Greenspector](https://greenspector.com/en/publicationss/) |
+
+**IMPORTANT**: Not all frameworks listed above are independent. Several tools use the same underlying model, which is essential context for interpreting comparative scores.
+
+The following matrices evaluate each approach against evaluation criteria from Section 4, with additional practical adoption criteria identified through community feedback.
+
+**Scoring Scale:**
+- 5: Excellent - Fully meets criteria with strong evidence
+- 4: Good - Substantially meets criteria with minor gaps
+- 3: Adequate - Partially meets criteria with notable limitations
+- 2: Limited - Minimally addresses criteria with significant gaps
+- 1: Insufficient - Does not adequately address criteria
+- ~: Preliminary - Insufficient information for confident scoring
+
+### Core Evaluation Criteria (from Section 4)
+
+| Framework | Accuracy | Simplicity | Trust | Boundaries | Functional Units | Gaming Prevention | Personas | Incentives | **Core Avg** |
+|-----------|----------|-----------|-------|------------|------------------|-------------------|----------|------------|--------------|
+| **SWDM / CO2.js** | 3 | 5 | 4 | 4 | 2 | 2† | 3 | 3 | **3.3** |
+| **Website Carbon Calc** | 2 | 5 | 3 | 2 | 2 | 1† | 2 | 2 | **2.4** |
+| **Ecograder** | 3 | 4 | 3* | 3 | 2 | 2† | 3 | 3 | **2.9** |
+| **W3C WSG** | 2* | 2 | 3 | 3 | 3 | 2 | 4‡ | 4 | **2.9** |
+| **Parent SCI** | 3 | 2 | 4 | 4 | 3 | 3 | 4 | 4 | **3.4** |
+| **Cardamon** | 4 | 3 | 4 | 4 | 4 | 3 | 3 | 4 | **3.6** |
+| **Green Metrics Tool** | 4 | 2 | 5 | 4 | 5 | 4 | 3 | 4 | **3.9** |
+| **Greenspector** | ~4 | ~3 | ~4 | ~3 | ~4 | ~3 | ~3 | ~3 | **~3.4** |
+
+**Annotations:**
+- *W3C WSG Accuracy: Acknowledged to be improving with forthcoming measurement enhancements (no release date specified). Score may increase in future assessments.
+- *Ecograder Trust: Beta version now includes W3C WSG integration for improved guidance on specific improvements. Score reflects current production version capabilities.
+- ‡W3C WSG Personas: Filter system exists in full document mode to sort by category/role/discipline, reducing cognitive load. Upgraded filter system planned for main documentation.
+- †Gaming Prevention: Scores reduced by 1 point for SWDM-based frameworks (CO2.js, Website Carbon Calculator, Ecograder) that rely on automatic "green hosting" detection via IP/hosting provider lookup. This approach is deeply flawed for enterprise environments with CDNs and complex hosting architectures, enabling potential gaming through hosting provider selection signals rather than genuine carbon reductions.
+- ~Greenspector scores are preliminary assessments based on limited publicly available documentation. Full methodology review would enable confident scoring.
+
+**Note on SWDM-based tool scoring**: CO2.js, Website Carbon Calculator, and Ecograder share underlying SWDM methodology and therefore have similar accuracy, functional unit, and gaming prevention characteristics. Differences in other criteria reflect application-level distinctions (UI, additional features, documentation).
+
+SCI for Web should aim to maximise its average score on the above matrix, and ensure the average score exceeds any existing entry.
+
+---

--- a/sci-web/docs/phase-1/initial-questionnaire.md
+++ b/sci-web/docs/phase-1/initial-questionnaire.md
@@ -1,0 +1,11 @@
+Please answer the following questions and email your answers to harmony@greensoftware.foundation
+
+1.  Tell us about your journey to this table - what's your background, and what specific experience do you have with either website carbon measurement, the SCI standard, or sustainable web development?
+
+2. If we successfully adapt SCI for websites, what would that enable you or your organisation to do that you can't do today?
+
+3. What's one aspect of current website carbon measurement that keeps you up at night - whether it's a technical limitation, a methodological concern, or a practical implementation challenge?
+
+4. Are there any areas of controversy or uncertainty regarding website carbon measurement that you want to make sure gets tackled in the SCI for Web standard?
+
+5. Do you have any feedback on the research note shared above - what's missing, what did we get wrong? 

--- a/sci-web/docs/phase-1/participant-guide.md
+++ b/sci-web/docs/phase-1/participant-guide.md
@@ -1,0 +1,338 @@
+# SCI for Web Assembly - Participant Handout
+
+## **Summary**
+
+The SCI for Web Assembly is an **asynchronous, consensus-driven process** designed to develop the industry standard for measuring website carbon emissions. This assembly operates through **rapid 2-day email cycles** with GitHub transparency and selective live sessions only when objections cannot be resolved asynchronously.
+
+**SCI for Web details:** [https://assemblies.greensoftware.foundation/sci-for-web](https://assemblies.greensoftware.foundation/sci-for-web)
+
+---
+
+## **Key Dates & Timeline**
+
+* **Pre-Assembly Questionnaire:** September 15-22, 2025 (1 week)
+* **Consensus Building:** September 22 - December 1, 2025 (10 weeks)
+  * **Scope Definition:** Sept 22 - Oct 6 (2 weeks)
+  * **Quality Rubric:** Oct 6 - Oct 20 (2 weeks) 
+  * **Target Personas:** Oct 20 - Nov 3 (2 weeks)
+  * **Behavioral Incentives:** Nov 3 - Nov 17 (2 weeks)
+  * **Comparative Analysis:** Nov 17 - Dec 1 (2 weeks)
+* **Report Finalization:** December 1-8, 2025 (1 week)
+* **Total Duration:** Approximately 13 weeks
+* **Timeline Flexibility:** If consensus is reached faster on any area (e.g., 1 week instead of 2), the overall timeline may be shortened accordingly
+* **Capacity:** Maximum 20 participants
+* **Time Commitment:** 30 minutes every 2 days, work on your schedule
+
+---
+
+## **The Async-First Process**
+
+### **Core 2-Day Cycle**
+Every consensus area follows this rapid cycle:
+
+**Type 1: Question Emails**
+1. **Monday:** Engineered question email sent to all participants
+2. **Wednesday:** Free-form response deadline (2 days to respond - as detailed and wordy as you want)
+
+**Type 2: Synthesis Emails**  
+3. **Wednesday:** AI synthesis email sent back containing:
+   - Areas of agreement across all responses
+   - Areas of disagreement with specific participant positions
+   - Outlier viewpoints tagged to individuals
+   - Candidate statement for consensus
+4. **Friday:** Endorse/Consent/Object responses due
+5. **Repeat** synthesis cycles until consensus or escalate to live call
+
+### **Why 2-Day Cycles?**
+- **Maintains momentum** - no waiting weeks for responses
+- **Global accessibility** - enough time across all time zones  
+- **Forces focus** - prevents overthinking and analysis paralysis
+- **Creates urgency** - drives engagement and decision-making
+
+### **Sequential Consensus Areas**
+Each area **must** be completed before moving to the next due to dependencies:
+
+1. **Scope Definition** → *What applications are in/out of scope?*
+2. **Quality Rubric** → *How do we evaluate success within that scope?*
+3. **Target Personas** → *Who adopts this within scope for quality goals?*
+4. **Behavioral Incentives** → *What specific behaviors should personas change?*
+5. **Comparative Analysis** → *How do existing approaches measure against our framework?*
+
+---
+
+## **What Makes This Different**
+
+### **Boundary-Finding Focus**
+We're not seeking broad agreement - we're finding the **edges of boundaries**:
+- Where does "web application" end and "API" begin?
+- Which personas are **essential** vs nice-to-have?  
+- What quality criteria are **mandatory** vs optional?
+
+### **Engineered Questions**
+Each question is crafted to surface disagreement through:
+- **Opposing viewpoints** built into the question
+- **Edge cases** that force boundary decisions
+- **Artificial constraints** (e.g., "Pick only 3 personas")
+- **Implementation specifics** not just philosophy
+
+### **Two Types of Email Responses**
+
+**Question Email Responses:**
+- **Free-form response** to the question asked
+- **Encourage detailed, wordy responses** - more content helps AI synthesis
+- **No structure required** - just respond naturally to the question
+- **No endorse/consent/object** needed at this stage
+
+**Synthesis Email Responses:**
+Every synthesis includes a **candidate statement** you can:
+- **ENDORSE** - Actively support and advocate for (no rationale required)
+- **CONSENT** - Can live with, though not ideal (no rationale required)  
+- **OBJECT** - Cannot proceed without changes + **must explain what needs to change**
+
+---
+
+## **Participation Format**
+
+### **Pre-Assembly Materials & Questionnaire (1 Week)**
+**September 8-15, 2025**
+
+Before the assembly begins, you will receive:
+- **Pre-Assembly Questionnaire** (5 questions, 200 words each) - Separate questionnaire document
+- **Research Note** - GSF Head of Research & Development's analysis of current state-of-the-art in web carbon measurement, existing specifications, methodologies, and tools
+- **This Participant Handout** - Process guide and expectations
+
+*Response deadline: September 15, 2025*
+
+### **Consensus Building Phases (8 Weeks)**
+
+#### **Phase 1: Scope Definition (2 Weeks)**
+**September 22 - October 6, 2025**
+
+**Goal:** Crystal-clear boundaries for when to use SCI for Web vs other SCI specs
+
+**Key Boundary Questions:**
+- Single-page applications vs multi-page applications?
+- Client-side rendering vs server-side rendering?
+- Progressive web apps vs native mobile apps?
+- Web APIs called by websites vs standalone API services?
+- AdTech integrated in websites vs standalone AdTech platforms?
+
+**Success Criteria:** Clear in-scope/out-of-scope statement with edge cases resolved
+
+#### **Phase 2: Quality Rubric (2 Weeks)**  
+**October 6-20, 2025**
+
+**Goal:** Prioritized framework for evaluating SCI for Web effectiveness
+
+**Key Prioritization Questions:**
+- Measurement accuracy vs implementation simplicity?
+- Real-time measurement vs periodic assessment?
+- Cross-browser consistency vs platform optimization?
+- Developer usability vs procurement requirements?
+
+**Success Criteria:** Ranked quality criteria with clear evaluation methods
+
+#### **Phase 3: Target Personas (2 Weeks)**
+**October 20 - November 3, 2025**
+
+**Goal:** Essential adopter categories with specific behavioral targets
+
+**Key Persona Questions:**
+- Frontend developers vs full-stack developers vs DevOps?
+- Browser vendors vs hosting providers vs CDN operators?
+- Enterprise procurement vs startup teams vs open source maintainers?
+- **Constraint:** Maximum 5 primary personas allowed
+
+**Success Criteria:** Persona-behavior matrix showing who does what
+
+#### **Phase 4: Behavioral Incentives (2 Weeks)**
+**November 3-17, 2025**
+
+**Goal:** Specific behaviors SCI for Web should drive within defined scope
+
+**Key Incentive Questions:**
+- Smaller bundle sizes vs faster loading vs fewer requests?
+- Edge computing vs centralized hosting vs hybrid approaches?
+- Progressive enhancement vs single-page app optimization?
+- **Constraint:** Maximum 8 priority behaviors allowed
+
+**Success Criteria:** Ranked behavior list with persona mappings
+
+#### **Phase 5: Comparative Analysis (2 Weeks)**
+**November 17 - December 1, 2025**
+
+**Goal:** Evaluate existing approaches against our consensus framework
+
+**Key Analysis Questions:**
+- How do current carbon measurement tools align with our scope definition?
+- Which existing solutions meet our quality rubric requirements?
+- What gaps exist in current approaches for our target personas?
+- How well do existing tools drive our prioritized behavioral incentives?
+
+**Success Criteria:** Comprehensive analysis of existing landscape against consensus framework
+
+### **Report Finalization (1 Week)**
+**December 1-8, 2025**
+
+Consolidate all consensus decisions into final Assembly Report for publication.
+
+## **How to Participate**
+
+### **Question Email Responses**
+When you receive a question email:
+- **Reply directly to the email** with your thoughts
+- **Be as detailed and wordy as you want** - more tokens help AI synthesis
+- **No specific format required** - just respond naturally
+- **Submit by the stated deadline** (usually 2 days)
+
+### **Synthesis Email Responses**  
+When you receive a synthesis email with candidate statement:
+- **Reply with:** `ENDORSE`, `CONSENT`, or `OBJECT`
+- **For ENDORSE/CONSENT:** No additional explanation required (though optional)
+- **For OBJECT:** You MUST explain what needs to change for you to move to consent/endorse
+
+### **Object Response Requirements**
+If you object, your response must explain:
+- **What specifically you object to** in the candidate statement
+- **What needs to change** for you to move to consent or endorse  
+- **The path forward** you see for reaching consensus
+- **Your reasoning** - you must be prepared to defend your objection
+
+**Important:** Objecting is not casual. If you object, you're committing to help find a solution and participate in resolution discussions.
+
+### **Objection Resolution Process**
+
+1. **Object via synthesis email response** with detailed rationale of what needs to change
+2. **Additional synthesis rounds** incorporating all objection feedback into new candidate statements
+3. **Still objecting after multiple rounds?** → Mandatory live call scheduled
+4. **Live session attendance required** for people who endorsed AND people who objected
+5. **No consensus after 2 weeks?** → Proceed to supermajority vote
+6. **Vote outcome becomes final decision** and process moves to next consensus area
+
+---
+
+## **Meeting Philosophy**
+
+### **Standing Bi-Weekly Meetings**
+- **Reserved in your calendar** for full assembly duration
+- **Used ONLY for objection resolution** - not routine progress
+- **Mandatory attendance** if you've objected to the topic
+- **Optional attendance** for non-objecting participants
+- **72-hour notice** required for activation
+
+### **No Regular Meetings**
+- Primary work happens via **email + GitHub**
+- **Face-to-face interaction** only when async breaks down
+- **Global time zone friendly** - work on your schedule
+- **Documentation-driven** process with full transparency
+
+---
+
+## **Tools & Communication**
+
+### **Primary Channel: Email**
+- Structured question delivery every 2 days
+- Response collection with clear deadlines  
+- Synthesis summaries with candidate statements
+- Objection notices and resolution coordination
+
+### **Documentation: GitHub** 
+- All responses published with attribution
+- Complete decision audit trail maintained
+- Draft report.md updated in real-time
+- Pull request comments for retrospective changes
+
+### **Escalation: Zoom + Miro**
+- Live objection resolution sessions
+- Visual collaboration for complex disagreements
+- Recorded for absent participants
+- Used sparingly to maintain async benefits
+
+---
+
+## **The Living Report**
+
+### **REPORT.md File**
+- **Every consensus decision** is added to the `REPORT.md` file after consensus is reached
+- **Updated throughout assembly** as each consensus area completes
+- **Published publicly** only after the assembly is fully complete to GSF membership
+- **Not the specification** - this report drives what the specification will be
+- **Conversations remain private** - only consensus decisions are published
+
+### **Publication Timeline**
+- **Scope consensus** → Added to REPORT.md
+- **Quality rubric consensus** → Added to REPORT.md  
+- **Persona consensus** → Added to REPORT.md
+- **Behavioral incentives consensus** → Added to REPORT.md
+- **Comparative analysis consensus** → Added to REPORT.md
+- **Assembly completion** → REPORT.md published publicly to GSF membership and broader community
+
+---
+
+## **Participant Expectations**
+
+### **Your Commitment**
+- **Response discipline:** 2-day turnaround on all questions
+- **Boundary focus:** Help find edges rather than seek broad agreement  
+- **Implementation perspective:** Consider real-world deployment challenges
+- **Consensus support:** Honor agreed decisions even if not your preference
+- **GitHub engagement:** Review others' responses and synthesis summaries
+
+### **What We Provide**
+- **Structured process:** Clear methodology preventing deadlock
+- **Question engineering:** Crafted to surface productive disagreement
+- **AI synthesis:** Rapid processing of responses into actionable insights
+- **Escalation support:** Live facilitation when async reaches limits
+- **Documentation:** Complete record of all decisions and rationale
+
+---
+
+## **Success Metrics**
+
+### **Process Success**
+- Average 3-5 cycles per consensus area (rapid convergence)
+- <20% of topics require live objection sessions  
+- 100% participant response rate within 2-day windows
+- Clear consensus achieved on all 4 major areas
+
+### **Content Success**  
+- Sharp scope boundaries distinguishing SCI for Web from other specs
+- Implementable quality framework with measurable criteria
+- Actionable behavioral incentives mapped to specific personas
+- Foundation ready for formal specification development
+
+---
+
+## **FAQ**
+
+**Q: What if I miss a 2-day response deadline?**
+A: Contact [assemblies@greensoftware.foundation](mailto:assemblies@greensoftware.foundation) immediately. Synthesis proceeds without late responses, but you can still participate in subsequent rounds.
+
+**Q: Do I need to follow a specific format when responding to questions?**
+A: No format required for question emails - just respond naturally and be as detailed as you want. For synthesis emails, just reply with ENDORSE/CONSENT/OBJECT.
+
+**Q: What if I want to object but don't have a complete alternative solution?**
+A: You don't need a complete alternative, but you must explain what needs to change for you to move to consent/endorse. Focus on what's wrong and what direction would work better.
+
+**Q: Can I change my position between cycles?**
+A: Yes, until final consensus. Each synthesis round is a fresh opportunity to endorse, consent, or object based on the updated candidate statement.
+
+**Q: What happens if I object but can't attend the live session?**
+A: Objection sessions are mandatory for objectors. If you can't attend, you should either withdraw your objection or designate someone to represent your position.
+
+**Q: How binding are the report.md consensus decisions?**
+A: Very binding. Each consensus decision is immediately published and becomes the foundation for specification development. You're committing to support these outcomes.
+
+**Q: What's the difference between this report and the actual specification?**
+A: The report documents our consensus decisions and becomes the foundation for future specification development. The actual technical specification will be developed later by ongoing working groups.
+
+---
+
+## **Contact & Support**
+
+- **Process Questions:** [assemblies@greensoftware.foundation](mailto:assemblies@greensoftware.foundation)
+- **Technical Issues:** GitHub issues in the assembly repository
+- **Urgent Objections:** Direct contact with Chris Adams (Project Lead)
+- **Administrative:** Joseph Cook (Assembly Coordinator)
+
+**Ready to define the future of web carbon measurement?** Your expertise and engagement will shape how the industry measures and reduces website emissions for years to come.

--- a/sci-web/docs/phase-1/research-brief.md
+++ b/sci-web/docs/phase-1/research-brief.md
@@ -1,0 +1,124 @@
+# Website Carbon Measurement
+
+# Executive Summary
+
+Website carbon emission measurement has evolved significantly over the past few years. Today, the dominant methods for website carbon emissions measurements are the Sustainable Web Design Model v4 and, increasingly, the Software Carbon Intensity (SCI) standard adoption. However, both of these methods have significant limitations. Page weight is an imperfect proxy for emissions, and the SCI standard lacks specific guidance for web-specific applications. Here we’ll explore the current state of the art, compare the competing methodologies and point out opportunity areas where the SCI for Web might focus.
+
+## 1\. The Current Industry Standard
+
+### Sustainable Web Design Model v4
+
+The Sustainable Web Design Model (SWDM) v4, released July 2024, represents the current industry standard for website carbon calculations. It sums the contributions from three components to yield a website carbon emissions score in units of gCO2e/page view:
+
+- **Data centers**: 22% of system energy (290 TWh globally) \- 82% operational, 18% embodied emissions  
+    
+- **Networks**: 24% of system energy (310 TWh) \- 82% operational, 18% embodied emissions  
+    
+- **User devices**: 54% of system energy (421 TWh) \- 49% operational, 51% embodied emissions
+
+Version 4's calculation formula is as follows:
+
+```
+Average Emissions per Page View (gCO2e) = 
+[(OPDC × (1 - Green Hosting Factor) + EMDC) + (OPN + EMN) + (OPUD + EMUD)] × New Visitor Ratio) + ([(OPDC × (1 - Green Hosting Factor) + EMDC) + (OPN + EMN) + (OPUD + EMUD)] × Return Visitor Ratio × (1 - Data Cache Ratio))
+
+Where:
+
+OPDC – Operational Emissions Data Centers.
+Green Hosting Factor – The portion of hosting services powered by renewable or zero-carbon energy, between 0 and 1 (see FAQ).
+EMDC – Embodied Emissions Data Centers.
+OPN – Operational Emissions Networks.
+EMN – Embodied Emissions Networks.
+OPUD – Operational Emissions User Devices.
+EMUD – Embodied Emissions User Devices.
+New Visitor Ratio – The portion of first time visitors to a web page, between 0 and 1.
+Return Visitor Ratio – The portion of returning visitors to a web page, between 0 and 1. (What is this? See FAQ)
+Data Cache Ratio – The portion of data that is loaded from cache for returning visitors, between 0 and 1. (What is this? See FAQ)
+
+```
+
+Emissions estimates were reduced by 60-66% in Version 4 compared to Version 3\. Despite being the industry standard, SWDM v4 has faced criticism, especially around the suitability of page weight as a predictor of actual carbon emissions (e.g. [DebugBear, 2024](https://www.debugbear.com/blog/website-carbon-emissions)). 
+
+Other methodologies include the OneByte model, originating from The Shift Project, which offers simplicity but excludes significant emission sources. DIMPACT, developed by University of Bristol with industry partners, provides the most data-driven approach but requires a lot of data disclosure, which in turn relies upon extensive partner cooperation. The SCI standard is arguably the most comprehensive framework but it was designed for general software rather than websites, meaning it is lacking in specific guidance for measuring web applications.
+
+## 2\. Alternative Methodologies Comparison
+
+### Methodology Landscape
+
+The following table compares the main methodologies used to measure website carbon emissions today.
+
+| Dimension | SWDM v4 | OneByte Model | DIMPACT | SCI (ISO/IEC 21031:2024) |
+| :---- | :---- | :---- | :---- | :---- |
+| **Scope & Boundaries** | Cradle-to-grave: data centers, networks, user devices | Gate-to-gate: data centers and networks only | Complete digital media value chain | Flexible boundaries defined per software system |
+| **Primary Metric** | CO2e per page view | CO2e per byte transferred | Process-based emissions per media asset | Carbon intensity per functional unit |
+| **Formula Complexity** | Multi-factor with cache ratios and visitor types | Linear: Data × Energy × Carbon intensity | Activity-based with detailed process mapping | SCI \= ((E × I) \+ M) per R |
+| **Embodied Emissions** | Included: 18% for infrastructure, 51% for devices | Excluded | Included through detailed equipment inventory | Included (M component) with time/resource allocation |
+| **Functional Units** | Fixed: per page view | Fixed: per GB transferred | Flexible: per hour viewed, per asset delivered | Flexible: per user, transaction, API call, etc. |
+| **Energy Data Source** | Global averages: 0.055-0.080 kWh/GB by segment | Fixed: 0.06 kWh/GB (2018 data) | Actual measurements from partners | Real telemetry or lab measurements |
+| **Carbon Intensity** | Global average: 494g CO2e/kWh | User-selectable or global average | Regional grid factors | Location-specific, excludes market measures |
+| **Caching Consideration** | 75% new, 25% return with 98% cache efficiency | Not considered | Detailed CDN modelling | Not specified |
+| **Green Hosting** | Includes green hosting factor | Not considered | Actual energy sourcing data | Excludes renewable certificates |
+| **Validation Method** | Industry review, no empirical validation | Academic origin, limited validation | Industry \+ academic validation | Requires measurement documentation |
+| **Best Use Case** | General website assessment | Quick estimates, browser extensions | Media streaming and broadcasting | Software applications with clear boundaries |
+| **Key Limitation** | Page weight as imperfect proxy | Oversimplified, outdated factors | Complex data requirements | Requires adaptation for web contexts |
+
+## 3\. Refining the SCI Standard for Web
+
+The Software Carbon Intensity (SCI) standard (ISO/IEC 21031:2024) is calculated as:
+
+**SCI \= ((E × I) \+ M) per R**
+
+Where:
+
+- E \= Energy consumed by software system (kWh)  
+- I \= Location-based carbon intensity (gCO2eq/kWh)  
+- M \= Embodied carbon emissions from hardware  
+- R \= Functional unit (per user, transaction, request)
+
+### 
+
+The SCI has some key advantages over competing methodologies, including a scope that encompasses operational energy, carbon intensity, AND embodied emissions, flexibility in functional unit choice, an unopinionated approach to the route users take to measure E, I, M and R, exclusion of offsets (no “market based” measures allowed), detailed handling of hardware and recognition from ISO.
+
+However, the SCI specification is designed to apply broadly to all software, meaning there is a lack of particular guidance for websites. Some of the key areas of uncertainty are
+
+**Functional Unit Definition**: There are many units that could be appropriate for expressing website carbon emissions, for example page views, unique visitors, MAU, transactions, content delivery, API calls, etc. SCI does not currently give guidance regarding which functional units are appropriate for different web use cases.
+
+**Boundary Determination**: Modern websites are served on complex distributed infrastructure, including third-party scripts, CDNs, external APIs, client/server processing splits, and progressive web apps. SCI does not define where the system boundary lies.
+
+**Energy Measurement**: Users often have limited access to actual consumption data, especially in shared hosting environments, serverless architectures, etc, and SCI does not suggest appropriate proxies or methodologies for converting those proxies into energy estimates.
+
+**Embodied Emissions**: It is difficult to determine the appropriate physical resource-share for websites using shared infrastructure and user devices running thousands of applications. SCI currently only gives high level instructions for amortizing hardware emissions.
+
+## 4\. Opportunities for SCI for Web
+
+Based on the uncertainties identified above, these are some potential valuable deliverables for SCI for Web:
+
+- Provide a rubric for choosing an appropriate functional unit that addresses the main web architectures.  
+- Define an appropriate system boundary. Make it clear what components are in/out of scope for an SCI measurement.  
+- Provide a hierarchy of proxy data sources and recommended methodologies for converting them into E, I, M or R.  
+- Clarify the allocation strategy for hardware emissions, including for complex shared resources.  
+- Include a degree of cache-awareness.Differentiate new vs returning visitor impacts, account for CDN hit rates, browser caching etc.
+
+These could then be wrapped in the language of the SCI specification for submission to ISO.
+
+## 5\. SCI for Web case study
+
+**Cardamon**, developed by Root & Branch Digital, pioneered the first website measurement tool explicitly built to comply with the SCI standard (ISO/IEC 21031:2024). 
+
+Key features of Cardamon's SCI implementation:
+
+1. **Scenario-based measurement**: Cardamon is built around the concept of observations and scenarios. A scenario encapsulates a usage behaviour that you want to measure (e.g. add items to basket), compatible with ISO/IEC 21031 \- Software Carbon Intensity (SCI) specification.  
+     
+2. **Real power consumption tracking**: Unlike tools relying on data transfer proxies, Cardamon collects data every 2 seconds to measure actual power consumption of software processes, including Docker containers and bare-metal applications.  
+     
+3. **Functional unit flexibility**: Scenarios can represent any user behaviour, allowing measurement per transaction, per user action, or custom functional units as required by SCI.  
+     
+4. **Configuration-based approach**: Uses a `cardamon.toml` file to define:  
+   * CPU specifications with average power consumption  
+   * Processes to measure (Docker or bare-metal)  
+   * Scenarios representing user behaviours  
+   * Observations combining scenarios and processes  
+       
+5. **Iterative measurement**: Scenarios can be run multiple times to take an average, improving accuracy of carbon intensity calculations.
+
+This implementation addresses several SCI adaptation challenges for websites by providing scenario-based functional units, actual energy measurement rather than proxies, and support for distributed architectures through Docker container tracking. It is probably well worth engaging the developers of Cardamon to benefit from their experiences and understand their design decisions as we develop SCI for Web.

--- a/sci-web/docs/phase-1/spec_template.md
+++ b/sci-web/docs/phase-1/spec_template.md
@@ -1,0 +1,228 @@
+>IN DRAFT - DO NOT CHANGE
+
+## Scope
+
+```
+Define as it relates to Green Software Foundation Activity. If it adds clarity, define what is not in the scope. DELETE THIS COMMENT 
+```
+
+## References
+### Normative References
+
+```
+The policy for reference lists is:
+1. GSF documents listed should have at least one approved version – draft-only docs should not be referenced.
+An exception exists for documents approved with or after the referenced doc is approved (maybe part of the same enabler package). In short – approved docs should not reference unapproved docs.
+2. The name + version (no date) for GSF specifications are generally sufficient – dates should be used only if there is a specific reason to limit the usage.
+3. References to other affiliate docs should similarly provide sufficient information to uniquely determine the needed document and should provide the appropriate source information.
+4. The URL for GSF material (new GSF and affiliate) should always be http://www.greensoftware.foundation
+    
+Models to use:
+	[REFLABEL]	<General Model> "Ref Title", Ref information (source, date, id), URL:http//<ref-source>/ 
+	[GSFDOC]	<GSF Model> "GSF Document Title",{ Version x.y,} Green Software Foundation™, GSF <docname>{    <version>}, URL:http//www.openmobilealliance.org/ 
+
+If there are no entries in the table – enter 'none' to be precise.
+
+DELETE THIS COMMENT
+```
+<table>
+  <caption>Normative References </caption>
+  <tbody>
+    <tr>
+      <td><strong>[RFC2119]</strong></td>
+      <td>"Key words for use in RFCs to Indicate Requirement Levels", S. Bradner, March 1997, URL:http://www.ietf.org/rfc/rfc2119.txt</td>
+    </tr>
+    <tr>
+      <td><strong>[RFC5234]</strong></td>
+      <td>"Augmented BNF for Syntax Specifications: ABNF", D. Crocker, Ed., P. Overell, Janury 2008, URL: https://tools.ietf.org/rfc/rfc5234.txt</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+Add/Remove reference rows as needed - DELETE This Row 
+```
+
+### Informative References
+
+```
+Check the version of the Dictionary you are using and update the reference below. Delete the [GSFDICT] entry if the Dictionary is not used. In general, use the latest
+available version unless seeking alignment with an existing set of specifications.
+
+DELETE THIS COMMENT
+```
+<table>
+  <caption>Informative References </caption>
+  <tbody>
+    <tr>
+      <td><strong>[GSFDICT]</strong></td>
+      <td>"Dictionary for GSF Specifications", Version x.y, Green Software Foundation™, GSF-ORG-Dictionary-Vx_y, URL:http://greensoftware.foundation/</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+Add/Remove references as needed - DELETE This Row
+```
+
+## Terminology and Conventions
+### Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119].
+
+All sections and appendixes, except "Scope" and "Introduction", are normative unless they are explicitly indicated to be informative.
+
+```
+If needed, describe or declare using appropriate normative references the additional conventions that are used. DELETE THIS COMMENT
+```
+
+### Definitions
+
+```
+Add definitions in new rows of the following table as needed. The following examples show how dictionary references should be made as well as locally defined terms. This table should be maintained in sorted alphabetic order based on the labels of the terms.
+
+Examples:
+	Entity              Use definition #1 from [GSFDICT]
+	Interactive Service Use definition from [GSFDICT]
+	Local Term          The definition description would be presented directly
+
+DELETE THIS COMMENT
+```
+<table>
+  <caption>Definitions</caption>
+  <tbody>
+    <tr>
+	<td><strong>Definition-1</strong></td>
+	<td>Description definition-1</td>
+    </tr>
+    <tr>
+	<td><strong>Definition-2</strong></td>
+	<td>Description definition-2</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+Add/Remove definition rows as needed - DELETE This Row
+```
+
+Kindly consult [GSFDICT] for more definitions used in this document.
+
+### Abbreviations
+
+```
+Add abbreviations as needed. No special notation should be made regarding terms copied from the Dictionary.  
+The list should be maintained in alphabetic order. DELETE This Row
+```
+
+<table>
+<caption>Definitions</caption>
+<tbody>
+  <tr>
+    <td>GSF</td>
+    <td>Green Software Foundation</td>
+  </tr>
+</tbody>
+</table>
+
+## Introduction
+
+```
+From a market perspective...  
+
+* What can you do with this specification?
+* What problem does this solve?
+* How can this specification be applied?
+* Consider the target audience and provide deployment examples as possible.
+
+DELETE THIS COMMENT
+```
+
+### Version 1.0
+
+```
+This section provides a high level, concise and informative description of the main functionality supported in the initial version of the specification. The description should be brief; the target length should be a few paragraphs. 
+When the enabler or reference release is finished, this description should be aligned with the final functionality. 
+
+DELETE THIS COMMENT
+```
+
+### Version (x.y)
+
+```
+This section should be included for each new major or minor version of the specification.
+
+It should provide a high level, concise and informative description of the new or modified functionality introduced in this version of the specification, compared to the previous version. The description should be brief, and the target length should be a few paragraphs. When the enabler or reference release is finished, this description should be 
+aligned with the final functionality differences.
+
+DELETE THIS COMMENT
+```
+
+#### Version (x.y.z)
+
+```
+Service indicator (z) for the document. It is incremented every time a corrective update is made to the approved document version by the WG. This section should describe the main changes made to the specification at a high level compared to the previous version. The description should be brief, and the target length should be one paragraph.
+
+DELETE THIS COMMENT
+```
+
+## Sections As Needed
+
+```
+Sections for the normative specification text. Fill in as needed. The following validates the styles used for the headers. DELETE THIS COMMENT 
+```
+
+### Example Level 2
+(Add text here.)
+
+#### Example Level 3
+(Add text here.)
+
+##### Example Level 4
+(Add text here.)
+
+
+<table>
+  <caption>Example Table</caption>
+  <thead>
+      <tr>
+	  <th>Item</th>
+	  <th>Function</th>
+	  <th>Reference</th>
+      </tr>	      
+  </thead>	    
+  <tbody>
+    <tr>
+	<td>Row 1</td>
+	<td>Grid 1,1 data</td>
+	<td>Grid 1,2 data</td>	    
+    </tr>
+    <tr>
+	<td>Row 2</td>
+	<td>Grid 2,1 data</td>
+	<td>Grid 2,2 data</td>	    
+    </tr>
+  </tbody>
+</table>
+
+## Appendix Change History (Informative)
+
+### Approved Version x.y History
+
+<table>
+    <caption>Approved Version x.y History</caption>
+    <thead>
+        <tr>
+            <th>Reference</th>
+            <th>Date</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>    
+        <tr>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>No prior version</td>
+        </tr>
+    </tbody>
+</table>

--- a/sci-web/docs/phase-2/assembly-plan.md
+++ b/sci-web/docs/phase-2/assembly-plan.md
@@ -1,0 +1,247 @@
+# SCI for Web Specification \-- Expert Assembly Programme
+
+**Purpose**: 
+
+This document reflects Harmony's architecture as of February 2026\.  
+This document defines a sequential programme for an assembled group of experts to refine SPEC-draft-v2.md into a final SCI for Web specification. Sessions are ordered by dependency: foundational decisions first, validation and sign-off last.
+
+---
+
+## Decision Model
+
+Each session should ultimately aim for consensus using the ENDORSE / CONSENT / OBJECT model used in the REPORT.md assembly process. Use Harmony DISCOVER and DELIBERATE phases to refine the content and navigate compromises and trade-offs such that what is presented for voting is highly likely to pass without objections. Where consensus cannot be reached, dissenting positions should be documented alongside the majority position.
+
+## Pre-Reading
+
+All participants should read before Session 1:
+
+- REPORT.md (design requirements)  
+- SPEC.md (the draft under review)  
+- Parent SCI Specification (ISO/IEC 21031:2024)  
+- Harmony primers
+
+---
+
+## Programme
+
+### Session 1: Formula Structure and Functional Units
+
+**Draft reference**: Sections 5, 6.4, 7, 8.1
+
+**Purpose**: Establish the complete architecture of the SCI equation \-- the six components in the numerator and the functional unit in the denominator. Every subsequent session depends on these being correctly defined.
+
+**Part A \-- Formula Validation**:
+
+1. **Are the six components correct and complete?** Is there a component missing (e.g., `M_network` for embodied emissions of network infrastructure)? Is any component unnecessary or redundant?  
+2. **Are the boundaries between components clear enough to prevent double-counting?** Specifically: where does O\_server end and O\_network begin for CDN edge servers? Where does O\_client end and O\_thirdparty begin for third-party scripts executing in the browser?  
+3. **Is the SWDM double-counting guidance sufficient?** SWDM allocates energy across datacenter, network, and end-user segments. The draft says to use only the network segment for O\_network. Is this workable?  
+4. **Should M\_network be included or explicitly excluded?** Network infrastructure has embodied emissions. Is the current implicit exclusion appropriate?
+
+**Part B \-- Functional Units**:
+
+5. **Are the recommended functional units per application type practical?** Can practitioners actually measure "content items consumed" or "tasks completed" with existing analytics tooling?  
+6. **Are the discouraged functional units correctly identified?** Are there cases where "page views" or "API calls" are genuinely the right choice?  
+7. **How should engagement thresholds be defined?** For "user session" \-- what constitutes a qualifying session? Mandate minimum thresholds or leave to organizations?  
+8. **What about multi-purpose applications?** Should different functional units apply to different sections, or must there be a single R?  
+9. **How do functional units handle bot traffic and non-human access?** Exclude from R, include, or handle differently?
+
+**Expected output**: Validated component list and boundary definitions. Refined functional unit guidance with practical measurement examples.
+
+---
+
+### Session 2: Server-Side and Network Measurement
+
+**Draft reference**: Sections 8.2, 8.3, 8.6
+
+**Dependency**: Session 1
+
+**Purpose**: Define the measurement methodology for components under infrastructure team control \-- server-side operational emissions (O\_server), network transfer emissions (O\_network), and server-side embodied emissions (M\_server). These are the best-understood components and form the measurement baseline.
+
+**Questions \-- Server-Side (O\_server, M\_server)**:
+
+1. **Is the PUE-based calculation sufficient for datacenter energy?** Should the specification provide default PUE values by provider type (hyperscale cloud, colocation, on-premise)?  
+2. **How should serverless and edge computing energy be attributed?** Cold starts, shared infrastructure, per-invocation billing \-- what allocation methodology is defensible?  
+3. **How should multi-tenant cloud infrastructure be attributed?** vCPU-based, memory-based, or cost-based allocation? What do cloud carbon tools actually provide?  
+4. **Are the M\_server calculation methods practical?** Can teams using cloud infrastructure actually obtain embodied emissions data? Which databases (Boavizta, CCF) are reliable?
+
+**Questions \-- Network (O\_network)**:
+
+5. **Is SWDM v4 the right default model?** What are its known limitations? Are the coefficients appropriate?  
+6. **Should the specification provide its own network energy coefficients?** If SWDM is insufficient, what alternatives exist?  
+7. **How should WiFi vs. cellular vs. wired be handled?** Require differentiation or accept a blended average?  
+8. **How should caching reduce O\_network?** If a returning user loads 80% from browser cache, should O\_network be 80% lower? How is this measured?  
+9. **What carbon intensity should be used for network infrastructure?** Is a global average the only practical option?
+
+**Expected output**: Validated server-side and network measurement methodology with recommended defaults and coefficients.
+
+---
+
+### Session 3: Client-Side Measurement
+
+**Draft reference**: Sections 8.4, 16
+
+**Dependency**: Session 1
+
+**Purpose**: Client-side measurement is the most novel and uncertain aspect of SCI for Web. This is where the REPORT.md identified the greatest tension between accuracy and feasibility. It warrants a dedicated session.
+
+**Questions**:
+
+1. **What tools and methods actually work for client-side energy measurement?** Browser DevTools give CPU/GPU time but not energy in kWh. What conversion factors or proxy models are defensible? What is the state of the art?  
+2. **How should the reference device list be maintained?** Name specific models updated annually, or maintain device classes and let organizations choose?  
+3. **Is the three-tier approach (reference device / device mix / RUM) correct?** Is RUM actually feasible for energy measurement with current browser APIs? What APIs exist or are emerging?  
+4. **How should screen energy be handled?** A significant portion of device energy during browsing is the display. Include in O\_client? If so, how?  
+5. **What default conversion factors should be provided?** If a team measures CPU time in milliseconds on a reference device, what factor converts to kWh? What research supports these factors?  
+6. **How should idle vs. active energy be attributed?** When a browser tab is open but the user isn't interacting, should baseline energy draw be attributed to the web application?
+
+**Expected output**: Validated client-side measurement methodology with specific tool recommendations, conversion factors, and handling of screen energy.
+
+---
+
+### Session 4: Third-Party Services, Embodied Emissions, and Default Values
+
+**Draft reference**: Sections 5.4, 8.5, 8.7
+
+**Dependency**: Sessions 1-3
+
+**Purpose**: Addresses the two areas where practitioners must rely most heavily on external data and estimation: third-party service emissions and embodied emissions from end-user devices. Both require the assembly to agree on defensible default values where direct measurement is impractical. Grouping them ensures consistent treatment of uncertainty and disclosure.
+
+**Questions \-- Third-Party Services (O\_thirdparty)**:
+
+1. **Are the three estimation methods (vendor disclosure, API call estimation, data transfer estimation) sufficient?** Are there other practical approaches?  
+2. **What default energy-per-API-call values are defensible?** The predraft suggested 0.0001 kWh per API call. Reasonable? For which service types?  
+3. **Should there be a mandatory minimum list of third-party services?** e.g., "Analytics, advertising, and payment processing SHALL always be included if present." Or is the 1% materiality threshold sufficient?  
+4. **How should client-side third-party scripts be attributed?** A GA script executes on the user's device (O\_client) and sends data to Google's servers (O\_thirdparty). Where does the energy go?  
+5. **What is realistic to expect from vendors?** Which vendors currently provide energy/carbon data? Is there a pathway to standardized vendor disclosure?  
+6. **How should advertising networks be handled?** Ad auctions, real-time bidding, and dynamic creative consume energy across multiple parties. Is there a practical approach?
+
+**Questions \-- Embodied Emissions (M\_client)**:
+
+7. **Are the default embodied emissions values correct?** What LCA databases support 400 kg for desktops, 300 kg for laptops, 100 kg for tablets, 80 kg for smartphones?  
+8. **Are the default lifespans correct?** 5 years for desktops, 4 years for laptops, 3 years for smartphones \-- do these match real-world replacement cycles?  
+9. **How should the default device mix distribution be determined?** The predraft suggested 30% desktop, 20% laptop, 40% smartphone, 10% tablet. What data supports this?  
+10. **How should resource-share work for client devices?** CPU utilization as a proxy \-- sufficient, or should GPU, memory, and display be considered?  
+11. **Should M\_client include peripherals?** External monitors, keyboards, chargers \-- include or exclude?  
+12. **How frequently should default values be updated?** Should the specification commit to an update cadence?
+
+**Expected output**: Refined third-party measurement methodology with default values. Validated embodied emissions defaults with cited sources. Governance process for maintaining default values over time.
+
+---
+
+### Session 5: Implementation Tiers, Tooling, and Disclosure
+
+**Draft reference**: Sections 9, 12, Appendix A
+
+**Dependency**: Sessions 1-4
+
+**Purpose**: With measurement methodology settled, this session defines how organizations adopt SCI for Web (tiers and tooling) and how they report results (disclosure). These are two sides of the same coin \-- tiers determine what you measure, disclosure determines what you report.
+
+**Questions \-- Implementation Tiers**:
+
+1. **Are the tier boundaries correct?** Is the jump from Entry to Standard too large? Is there a gap where many organizations would fall between tiers?  
+2. **Are Entry tier requirements achievable at zero cost?** The parent SCI specification says calculation "shall be possible without incurring any cost." Can a small team actually complete an Entry tier calculation?  
+3. **Should there be a "Starter" tier below Entry?** e.g., measuring only O\_server and O\_network with defaults for everything else?  
+4. **What specific tools satisfy each tier?** Name open-source tools for Entry tier today. Standard tier. Where are the gaps?  
+5. **How should tier advancement be incentivized?** Recommended timeline, or purely voluntary?  
+6. **Should the specification mandate minimum tiers for specific contexts?** Large organizations, public sector, or those making public sustainability claims?
+
+**Questions \-- Disclosure**:
+
+7. **What structured format should the disclosure template use?** JSON, YAML, JSON-LD? Align with existing sustainability reporting formats?  
+8. **What is the minimum viable disclosure?** The mandatory list has 10 items. Too many for Entry tier? Too few for credibility?  
+9. **Should there be a standardized badge or label format?** e.g., "SCI for Web: 7.96 gCO2eq/transaction \[Standard Tier\]" \-- embeddable on a website?  
+10. **How should disclosures be versioned and archived?** Should previous disclosures remain accessible?  
+11. **Should there be a registry of published SCI for Web scores?** This would enable industry benchmarking.
+
+**Expected output**: Validated tier definitions with tooling examples. Draft disclosure template with mandatory and optional fields.
+
+---
+
+### Session 6: Worked Examples, Reference Values, and Edge Cases
+
+**Draft reference**: Sections 11, 13, Appendices B-D
+
+**Dependency**: Sessions 1-5
+
+**Purpose**: Validate the specification end-to-end by working through complete calculations for realistic scenarios, and stress-test it against the diversity of real web architectures. This is where theory meets practice.
+
+**Questions \-- Worked Examples and Reference Values**:
+
+1. **Do the example calculations produce realistic numbers?** Are 7.96 g CO2eq per e-commerce transaction, 0.63 g per article read, and 30.7 g per SaaS session in the right order of magnitude?  
+2. **Can we produce a complete worked example with real data?** Walk through the full calculation for a real (or realistic) web application, identifying every data point, assumption, and estimation.  
+3. **What reference coefficients should Appendix C contain?** Compile the specific numbers: PUE defaults, network energy per GB, kWh-per-API-call defaults, carbon intensity global averages, etc.  
+4. **What tools should Appendix D recommend?** For each component and tier, which specific tools? Where are gaps?  
+5. **How do the examples validate against existing tools?** If we calculate a score and also measure with Green Metrics Tool or Cardamon, do results broadly agree?
+
+**Questions \-- Edge Cases and Architectural Patterns**:
+
+6. **Static sites with heavy client-side interactivity** (Jamstack \+ SPA hybrid): Where does SSG end and SPA begin? How should build-time vs. runtime be handled?  
+7. **Streaming media platforms**: Video/audio streaming is bandwidth-intensive. How should continuous media delivery be measured?  
+8. **Real-time collaborative applications**: WebSocket-heavy apps with persistent connections. How should always-on connections be attributed?  
+9. **Multi-tenant SaaS**: How should a single platform serving thousands of customers allocate emissions per customer?  
+10. **Micro-frontend architectures**: Multiple independently deployed frontends composed in the browser. Who owns the SCI score?  
+11. **Offline-first PWAs**: How should applications that sync periodically be measured?  
+12. **Multi-region CDN deployments**: Same content served from dozens of edge locations. How should I\_server be calculated?
+
+**Expected output**: Validated examples, populated appendices (reference values and tool directory), expanded edge case guidance.
+
+---
+
+### Session 7: Gaming Prevention and Adversarial Review
+
+**Draft reference**: Sections 7.4, 17, 18; REPORT.md Section 3 (Discouraged Practices)
+
+**Dependency**: Sessions 1-6
+
+**Purpose**: With the specification substantially complete, the assembly attempts to game it. Participants actively try to find ways to reduce scores without genuinely reducing emissions. This is an adversarial review, not a cooperative one.
+
+**Attack vectors to test**:
+
+1. **Energy displacement**: Can a team shift computation from O\_server to O\_client (or vice versa) to reduce their total SCI score? Does the comprehensive boundary prevent this?  
+2. **Boundary manipulation**: Can a team exclude high-emission components through creative boundary definition? Does the mandatory inclusion list prevent this?  
+3. **Functional unit gaming**: Can a team choose a functional unit that makes their inefficient application appear efficient?  
+4. **Third-party externalization**: Can a team outsource computation to third-party services to move emissions from O\_server to O\_thirdparty, then exclude them under the 1% materiality threshold?  
+5. **Quality degradation**: Can a team reduce page weight by degrading quality (low-res images, removed features) and show a lower SCI score?  
+6. **Tier shopping**: Can a team choose Entry tier specifically to avoid measuring components where they perform poorly?  
+7. **Measurement period cherry-picking**: Can a team select an atypical low-traffic period to improve their per-R score?
+
+For each vulnerability found, the assembly should either:
+
+- **Amend the specification** to close the vulnerability, or  
+- **Document it as a known limitation** where gaming cannot be fully prevented but is made detectable through disclosure requirements
+
+**Expected output**: Identified vulnerabilities with specification amendments. Documented known limitations.
+
+---
+
+### Session 8: Final Review and Sign-Off
+
+**Dependency**: Session 8
+
+**Purpose**: Final consensus session on the release candidate. The assembly formally endorses (or objects to) the specification for release to public comment.
+
+**Agenda**:
+
+1. Presentation of the release candidate (section-by-section summary)  
+2. Final ENDORSE / CONSENT / OBJECT round on the complete specification  
+3. Document any remaining objections or minority positions  
+4. Agree on post-assembly process:  
+   - Public comment period duration and mechanism  
+   - Pilot implementation candidates (aim for 3-5 organizations)  
+   - Governance for future specification updates and default value maintenance  
+   - Timeline to Version 1.0 publication  
+5. Close the assembly
+
+**Expected output**: Endorsed release candidate ready for public comment. Documented post-assembly governance.
+
+---
+
+## Post-Assembly Process
+
+After Session 8 sign-off:
+
+1. **Public comment period** (30 days): Open the release candidate for broader community review  
+2. **Comment resolution** (2 weeks): Address public comments, produce final specification  
+3. **Pilot implementation** (8-12 weeks): 3-5 organizations implement the specification and provide feedback  
+4. **Version 1.0 publication**: Final specification incorporating pilot feedback
+
+---

--- a/sci-web/docs/phase-2/harmony-critiques.md
+++ b/sci-web/docs/phase-2/harmony-critiques.md
@@ -1,0 +1,149 @@
+# Common Criticisms of LLM-Assisted Assemblies
+
+## Who this document is for
+
+If you're evaluating Harmony and have concerns about using AI in a deliberative process, or if you're anticipating those concerns from others, this document lays out the most common objections and how Harmony addresses them. We've tried to be honest about where trade-offs exist rather than pretending there are none.
+
+
+## "It removes the human connection"
+This is the most intuitive objection, and it deserves a careful answer.
+
+### What's actually being replaced
+Harmony doesn't replace human deliberation. It replaces the logistics of deliberation: scheduling meetings, managing turn-taking, taking minutes, circulating summaries. The humans still do all the thinking, writing, evaluating, and deciding. The AI reads what people wrote and identifies patterns. The humans judge whether those patterns are right.
+
+### What's gained by removing the room
+The face-to-face meeting is often held up as the gold standard for deliberation. But research on group dynamics consistently shows that in-person discussions amplify certain biases:
+
+- Dominance effects. A small number of speakers consume the majority of airtime. Quieter participants -- who may hold important minority views -- self-censor or never get the floor.
+- Conformity pressure. People anchor to the first opinion expressed and adjust toward the perceived group consensus, even when they privately disagree (Asch conformity, groupthink).
+- Status effects. Seniority, confidence, and fluency are mistaken for correctness. The most articulate speaker wins, not the best idea.
+- Availability bias. Whatever was said most recently or most vividly dominates the group's memory of the discussion.
+
+An asynchronous, anonymised process neutralises all of these. Every participant gets equal space. Nobody knows who said what. The synthesis is based on all responses equally, not on who spoke last or loudest.
+
+## The connection that matters
+
+The purpose of a deliberative assembly is collective decision-making. The "connection" that matters is that each participant's concerns are heard, considered, and addressed. Harmony makes this verifiable: you can mathematically prove your response was included in the synthesis, and the minimax metric guarantees the process cannot ignore anyone's dissatisfaction.
+
+If your group also needs social connection, that's valuable, but it's a separate need that can be served with semi-regular drop-in calls. Conflating the two is how you end up with long meetings that are neither good socialising nor good decision-making.
+
+## Harmony can complement face-to-face processes
+
+Nothing prevents using Harmony alongside in-person discussion. The supplemental data feature lets facilitators incorporate meeting notes, Slack conversations, or phone call summaries into the assembly. An organisation might hold a workshop to surface initial views, then use Harmony to structure the convergence process across a distributed team. Or vice versa: run the assembly first to establish where people actually stand, then meet in person to discuss the remaining disagreements. Used this way, Harmony doesn't compete with human connection - it provides a substrate of structured, verifiable input that makes in-person time more productive.
+
+
+## "I don't trust AI to represent my views"
+This concern has several layers, and each one has a concrete answer.
+
+### The AI doesn't decide anything
+This is worth stating plainly. The AI synthesises -- it produces a summary of what the group said. It does not make decisions, cast votes, or determine outcomes. Every substantive decision (rating candidates, casting the final vote, objecting) is made by human participants. The AI is a lens, not a judge.
+
+### You can verify your inclusion
+Every response is cryptographically hashed and committed to a Merkle tree. After synthesis, you can receive an inclusion proof -- a short piece of data that mathematically proves your exact response was part of the input set. If your response had been altered or excluded, the proof would not validate. You can inspect the human-readable plaintext that was submitted to the model and verify it through a public web app.
+
+### The synthesis is checked before you see it
+Before any synthesis reaches participants, it passes through automated validation that checks for leaked participant identities, PII, and attribution. The facilitator reviews each synthesis before distribution. And every participant gets to respond to what the synthesis says - if it misrepresents the group's views, that will surface in the next round.
+
+### The minimax metric is a structural safeguard
+Even if the synthesis were imperfect, the decision process has a safety net: the minimax metric. A candidate position is not viable until even the least satisfied participant rates it at least 5/10. This means a biased synthesis that ignored someone's concerns would produce a candidate that person rates poorly, which the system would flag as non-viable. Bias in synthesis gets corrected by the rating mechanism.
+
+### The final vote is human, and it's a veto
+The DECIDE phase gives every participant the power to OBJECT, which blocks consensus entirely. This is not majority rule. If you feel the process has misrepresented you at any point, you can block the outcome and explain what needs to change. This structural guarantee works regardless of what the AI does.
+
+## "What about energy use and carbon emissions?"
+This is a legitimate concern, and we take it seriously. But we think the numbers will favour Harmony.
+
+### What Harmony displaces
+Consider what a traditional multi-round deliberation looks like: multiple video calls with all participants present, each lasting 60-90 minutes, requiring synchronous availability, and potentially requiring travel for hybrid or in-person formats.
+
+A typical 1-hour Zoom call with 10 participants uses roughly 0.3-1.5 kWh depending on video quality and hardware. A 3-round deliberation with 2 calls per round uses 6 calls, or roughly 2-9 kWh -- not counting travel, heating/cooling meeting rooms, or the embodied energy of maintaining office space.
+
+### What Harmony consumes
+A Harmony assembly makes approximately 5-15 LLM API calls depending on the number of rounds and participants. Each call processes a few thousand tokens. The total energy consumption for the LLM inference is on the order of 0.01-0.1 kWh for a complete assembly -- one to two orders of magnitude less than the video calls it replaces.
+
+### We track it
+Harmony records token usage for every API call throughout the assembly lifecycle. This means you can calculate actual energy consumption and carbon emissions for any specific assembly, rather than relying on estimates. The token-usage data is available per-assembly as a JSON file and is reported at conclusion.
+
+### The real emissions story
+The most carbon-intensive thing about traditional deliberation is travel. Even a single return flight for one participant to attend an in-person meeting dwarfs the energy cost of thousands of LLM API calls. But even for fully-remote teams, the cumulative energy cost of synchronous video calls - plus the infrastructure to support them (data centres for video streaming, always-on endpoints) - likely exceeds the burst compute cost of a handful of LLM inference calls.
+
+The honest framing is: LLM inference is not free, but it is dramatically cheaper than the activities it displaces.
+
+## "Isn't this just replacing human judgement with AI?"
+
+No. It's replacing human logistics with AI and keeping human judgement at every decision point.
+
+Here is what the AI does:
+
+- Read responses and identify themes, agreements, and disagreements
+- Draft candidate positions that attempt to balance competing concerns
+- Compute fairness metrics on participant ratings
+
+Here is what humans do:
+
+- Write their actual views
+- Rate candidate positions
+- Provide feedback on what's missing or wrong
+- Cast the final ENDORSE / CONSENT / OBJECT vote
+- Block consensus if their concerns aren't addressed
+
+The AI accelerates the boring parts (reading 20 responses and writing a summary) so that humans can focus on the hard parts (evaluating proposals and making judgement calls). This is augmentation, not replacement.
+
+
+## "What if someone games the system?"
+
+### Strategic voting in DELIBERATE
+A participant could dishonestly rate candidates to try to steer the outcome - for example, rating a strong candidate low to prevent it from clearing the viability threshold. This is a real concern, and it's not unique to AI-assisted processes (it affects any voting system).
+
+Harmony's mitigation is structural: the minimax metric means that gaming requires coordination among multiple participants to suppress a candidate. A single strategic voter can lower the minimax score, but the facilitator can see individual ratings and identify outlier behaviour. And the final DECIDE vote requires explicit ENDORSE/CONSENT/OBJECT rather than numeric scores, making strategic misrepresentation harder to sustain.
+
+### Adversarial framing in responses
+A more subtle attack: crafting responses that exploit how the LLM weighs input. For example, making false consensus claims ("everyone I've spoken to agrees that...") or using authority signalling ("industry best practice requires...") to anchor the synthesis toward a preferred outcome.
+
+We are transparent that this is a fundamental limitation of LLM-based synthesis. The system cannot distinguish legitimate persuasion from adversarial framing. The mitigations are:
+
+- The facilitator reviews each synthesis before distribution and can regenerate it
+- Every other participant gets to respond to the synthesis -- misleading framings will be challenged in subsequent rounds
+- The minimax metric catches outcomes that leave people dissatisfied, regardless of how the synthesis was steered
+- The veto in DECIDE is the final backstop
+
+No deliberative process is immune to rhetorical manipulation. The question is whether an LLM-mediated process is more vulnerable than a meeting. In a meeting, a skilled rhetorician can dominate the room in real time with no written record. In Harmony, every input is recorded, every synthesis is reviewable, and every participant gets equal space regardless of charisma.
+
+
+## "Who controls the prompts?"
+The prompts that instruct the AI are part of the codebase and are inspectable. The facilitator does not secretly control what the AI is told to do. The system prompts include explicit instructions to:
+
+- Not attribute statements to individuals
+- Not include participant identifiers
+- Focus on themes and collective insights
+- Produce structured output with consensus areas, disagreement areas, and uncertainty areas
+
+Organisations can customise prompts for their specific context, but the security constraints (anonymisation, PII redaction, output validation) are enforced at the code level and cannot be overridden by prompt customisation.
+
+## "What about LLM bias?"
+All LLMs carry biases from their training data. In the context of synthesis, this could manifest as the model giving more weight to perspectives that align with mainstream views, or framing issues through a particular cultural lens.
+
+Harmony's design limits the impact of model bias in several ways:
+
+- The model summarises; it doesn't originate. The synthesis is constrained by what participants actually wrote. The model cannot introduce positions that no participant holds.
+- Bias is surfaced by the rating mechanism. If the synthesis skews in a direction that doesn't represent the group, participants will rate the resulting candidates poorly. The minimax metric catches this.
+- The facilitator can regenerate. If a synthesis appears biased, the facilitator can regenerate it, edit it, or supplement it before distribution.
+- Multiple rounds correct for drift. Each round of participant feedback anchors the process back to what the group actually thinks, limiting how far model bias can push the outcome.
+
+The honest answer is that LLM bias is real and cannot be fully eliminated. But in a multi-round process with human ratings and veto power, its practical impact on outcomes is limited. The bigger risk in traditional deliberation is human bias (status effects, conformity pressure), which Harmony structurally eliminates.
+
+
+## "This is a solution looking for a problem"
+Some groups don't need structured deliberation. If your team is small, co-located, aligned, and has no history of meetings dominated by a few voices, a conversation around a table may be perfectly adequate.
+
+Harmony is designed for situations where the simpler approach breaks down:
+
+- Distributed teams that can't easily get in a room together
+- Cross-timezone groups where synchronous meetings always disadvantage someone
+- Sensitive topics where social pressure distorts what people say
+- Recurring disagreements where the same voices win every time and the same concerns go unaddressed
+- Regulatory or governance contexts where you need a verifiable audit trail of how a decision was reached
+- Large groups (15+) where round-table discussion becomes unwieldy
+- Multi-language groups where some participants are disadvantaged by meetings held in a single language
+
+If none of these apply to your situation, you may not need Harmony.

--- a/sci-web/docs/phase-2/harmony-process-primer.md
+++ b/sci-web/docs/phase-2/harmony-process-primer.md
@@ -1,0 +1,114 @@
+# What Is a Harmony Assembly?
+
+## tl;dr
+
+A Harmony assembly is a structured conversation that happens over email. A small group of people respond to questions, and AI synthesises everyone's input into shared positions that the group then refines and votes on. The whole process is designed so that no one gets left behind, and the process is provably fair. The system starts by specifically seeking solutions that the least-satisfied person can live with.
+
+You don't need to install anything. You just reply to emails.
+
+
+## How It Works
+
+An assembly moves through three phases. Each phase involves one or more rounds where you receive an email, reply to it, and then receive a synthesis of what everyone said.
+
+### Phase 1: DISCOVER -- "What does everyone think?"
+
+You'll receive an email with an open-ended question about the topic. Reply with your honest thoughts in your own words - freeform text is fine, bullet points are fine, voice-to-text is fine. Nobody is grading your prose.
+
+After everyone responds (or the deadline passes), AI reads all the responses and produces an anonymous synthesis: a summary of themes, areas of agreement, and areas of disagreement. No names are attached. You'll receive this synthesis by email.
+
+There may be follow-up rounds if the facilitator wants to explore disagreements or uncertainties further. Each round builds on the last.
+
+### Phase 2: DELIBERATE -- "Which approach works best?"
+
+Based on what the group said in DISCOVER, the system generates candidate content - concrete proposals for additions to the spec that try to capture different ways of balancing everyone's concerns. You'll typically see three candidates - one prioritising the satisfaction of the least agreeable person, one aiming for the highest mean satisfaction across the group and one 'anti-consensus' proposal that aims to provoke discussion. 
+
+*Your job is to rate each candidate from 0 to 10* and explain your reasoning. The system computes fairness metrics, paying particular attention to the lowest rating any candidate received. A candidate isn't considered viable until even the least enthusiastic participant rates it at least 5 out of 10 (this is the default - the thresholds are configurable).
+
+If no candidate clears that bar, the system drafts a revised candidate incorporating feedback and you rate again,until at least one candidate is viable. If multiple candidates are viable, the highest rated one wins.
+
+
+### Phase 3: DECIDE -- "All aboard?"
+
+The strongest candidate from DELIBERATE is put to a final vote. You have three options:
+
+**ENDORSE** -- "I actively support this."
+**CONSENT** -- "This isn't my first choice, but I can live with it."
+**OBJECT** -- "I cannot accept this."
+
+Any single OBJECT blocks consensus. If you object, you'll be asked to explain what specific change would upgrade your vote to at least CONSENT. The group may then run another DELIBERATE round to address your concerns.
+
+This means the process cannot simply outvote you. Your concerns have to be addressed - but the converse is also true; if you onbject you have to state what specific changes ould upgrade your vote to aty least CONSENT.
+
+## What's Expected of You
+
+- Reply to the emails. That's the main thing. The process works best with high participation.
+- Be honest. The synthesis is only as good as the input. If you have concerns, raise them.
+- Meet the deadlines. Each round has a response window (typically 48 hours). You'll get a reminder if you haven't responded. If you really struggle for time, a numeric score alone can be a sufficient minimum viable response!
+
+
+## Why Use AI for This?
+
+**It reveals hidden preferences.** 
+
+In a meeting or group chat, social dynamics shape what people say. Louder voices dominate. People self-censor to avoid conflict. AI-synthesised deliberation sidesteps this: everyone responds privately, and the synthesis surfaces patterns that might never emerge in a room -- including minority concerns that would otherwise be drowned out.
+
+**It works across time zones and languages**
+
+You respond when it suits you, from wherever you are. Because the AI works with the meaning of what you wrote rather than the exact words, participants can write in the style and tone they're most comfortable with and the synthesis still captures their position.
+
+**It's more sustainable**
+A multi-round deliberation that might otherwise require several video calls instead happens asynchronously over email. Fewer calls means lower energy consumption and less screen fatigue.
+
+**It incorporates information from outside the process**
+If relevant discussions happen elsewhere, like a call, meeting notes, out-of-band discussions, etc. the facilitator can fold that material into the synthesis as supplemental data. The process doesn't have to be the only channel for the conversation to benefit from those inputs.
+There are options for synthetic participation. In some configurations, AI-generated perspectives can be included alongside human responses, for example, to represent a stakeholder group that couldn't participate directly, or to stress-test a position. These are always flagged as AI-generated in the system's records.
+
+
+## How Do You Know the Process Is Fair?
+
+**Your response is cryptographically committed**
+
+Every response is hashed and included in a Merkle tree -- a data structure used to prove that a piece of data was included in a set without revealing the rest of the set. After each round, you can receive an inclusion proof: a short piece of data that mathematically proves your response was part of the synthesis input. It would be computationally infeasible to produce this proof if your response had been altered or excluded. You can view what was submitted to the model in human-readable plaintext, and then drop it into our public web app to verify that the precise text you reviewed was really included in the synthesis.
+
+**The synthesis is anonymous by design**
+The AI is specifically instructed never to attribute views to individuals. The synthesis describes themes, patterns, and tensions -- not who said what. This is enforced by automated validation that checks the output for leaked names or email addresses before it reaches you.
+
+**The minimax metric protects minority positions**
+The system doesn't just optimise for the average. It specifically tracks the lowest rating any participant gives a candidate. A proposal that delights nine people but is unacceptable to one person is not considered viable. The process keeps iterating until the least-satisfied person's concerns are addressed. This is later reinforced by our final voting round, where all objections have to be resolved.
+
+**Veto power in the final vote**
+The DECIDE phase gives every participant the ability to block consensus. This is not majority rule. A single OBJECT vote prevents adoption and forces the group to address the objection. This structural guarantee exists regardless of what the AI does.
+
+**Inputs are validated for manipulation**
+The system screens responses for prompt injection attempts (where someone tries to manipulate the AI by embedding instructions in their response). Suspicious inputs are flagged for the facilitator to review before synthesis.
+
+**PII is automatically redacted**
+If you accidentally include sensitive information like phone numbers or email addresses in your response, the system redacts it before the text reaches the AI. This is a safety net, not a replacement for being mindful about what you share.
+
+**There is a full audit trail**
+Every action - responses received, syntheses generated, emails sent, operator decisions - is logged with timestamps. The facilitator can produce a complete record of the process on request.
+
+
+## Frequently Asked Questions
+
+**Can other participants see my response? **
+No. All emails are sent using BCC. Participants see only the anonymous synthesis, never each other's raw responses.
+
+**What if I miss a deadline? **
+Your response won't be included in that round's synthesis, but you can still participate in future rounds. If you're slightly late, the facilitator may extend the deadline.
+
+**Can I change my mind between rounds?** 
+Yes. Each round is a fresh opportunity to express your current thinking. The process expects views to evolve.
+
+**How many rounds will there be?** 
+It depends on how quickly the group converges. A simple topic might need one DISCOVER round, one DELIBERATE round, and one DECIDE round. A contentious topic might need several rounds of DISCOVER and DELIBERATE before reaching DECIDE.
+
+**What happens if consensus isn't reached?** 
+The facilitator may run additional rounds, introduce revised candidates, or conclude the assembly without consensus. The process doesn't force agreement -- it just makes genuine agreement easier to find.
+
+**Who is the "facilitator" or "operator"?** 
+The person who set up the assembly. They control when rounds start and end, can extend deadlines, and review flagged responses. They don't control the AI synthesis itself, but they confirm the progression of the assembly from round to round, and they can trigger generating reports and metrics.
+
+**How energy/carbon-hungry is this process?** 
+We track all token usage throughout the assembly life-cycle, meaning we can generate consumption and emission estimates for specific assemblies. We expect that most assemblies run using Harmony will be less energy-hungry than most "traditional" assemblies because the AI usage displaces travel to a meeting location or multi-participant Zoom calls. The actual usage depends on the assembly length, configuration and number of participants.

--- a/sci-web/spec-snapshot.md
+++ b/sci-web/spec-snapshot.md
@@ -1,0 +1,1088 @@
+# Software Carbon Intensity for Web Specification (DRAFT SNAPSHOT)
+
+## 1\. Introduction
+
+This specification extends the Software Carbon Intensity (SCI) methodology to the unique characteristics of web applications. It provides a standardized method for measuring and reporting the carbon emissions associated with software systems that deliver functional value to human users primarily through browser-based interfaces accessed via HTTP/HTTPS protocols.
+
+Web applications consume energy across a distributed system encompassing servers, networks, content delivery systems, third-party services, and end-user devices. Unlike monolithic server-side software, where energy consumption is concentrated in datacenter infrastructure, web applications distribute computation and rendering across infrastructure that no single party fully controls. This specification addresses that distributed reality.
+
+The SCI for Web specification builds upon the core principles established in ISO/IEC 21031:2024 while adding considerations specific to web applications, including their distributed architecture, client-side execution model, dependency on third-party services, and the diversity of end-user devices and network conditions.
+
+This specification aims to:
+
+- Provide a consistent framework for measuring the carbon footprint of web applications across servers, networks, client devices, and third-party services  
+- Enable meaningful comparison between different web application implementations and architectures  
+- Guide practitioners in making environmentally responsible decisions in web application design, development, and operation  
+- Incentivize carbon efficiency improvements that represent genuine emission reductions rather than displacement or gaming  
+- Create market pressure for third-party service providers and hosting suppliers to disclose and reduce their carbon impact
+
+Like the parent SCI specification, SCI for Web is a rate rather than a total: carbon emissions per functional unit. Lower scores indicate better efficiency. Reaching zero is impossible, but continuous improvement is always possible. Reducing an SCI for Web score requires actual elimination of emissions through more efficient code, more efficient infrastructure, or lower-carbon energy sources. Market-based measures such as carbon offsets and renewable energy certificates do not reduce SCI for Web scores.
+
+This specification recognizes that web applications exist across a spectrum of complexity and organizational capability. It provides progressive implementation tiers that enable teams to start measuring with readily available tools and industry defaults, then advance to more sophisticated measurement as capability grows. All tiers are legitimate when methodology is transparently disclosed.
+
+## 2\. Scope
+
+This specification covers the full spectrum of browser-based web applications, defined by three essential criteria:
+
+1. **Delivery mechanism**: Content and functionality delivered over HTTP/HTTPS protocols  
+2. **Execution environment**: Rendering and execution occurring primarily within web browser environments or equivalent web rendering engines  
+3. **Interaction pattern**: Interfaces designed for direct human interaction and consumption rather than exclusively machine-to-machine communication
+
+### 2.1 Application Types In Scope
+
+- Static content websites (blogs, documentation, marketing pages)  
+- Dynamic web platforms (content management systems, portals)  
+- Single-page applications (SPAs)  
+- Progressive web applications (PWAs)  
+- Server-side rendered applications  
+- E-commerce systems  
+- Media streaming services delivered via browser  
+- Software-as-a-Service (SaaS) platforms  
+- Real-time collaborative tools (document editors, whiteboards, messaging)  
+- API-driven applications with browser-based interfaces
+
+### 2.2 Boundary Cases
+
+API-driven services require classification based on their primary access pattern:
+
+- **In scope**: APIs accessed primarily through browser-based interfaces, such as those with interactive documentation as the primary usage method, or APIs coupled with browser-based management dashboards, where the browser interface represents the primary human interaction mode  
+- **Out of scope**: Pure machine-to-machine APIs serving only programmatic clients; these should use the parent SCI methodology directly
+
+The determining factor is whether human users consume the service's value through browser rendering, not whether HTTP protocols are involved.
+
+### 2.3 Architectural Patterns In Scope
+
+- Client-side rendering (CSR)  
+- Server-side rendering (SSR)  
+- Static site generation (SSG)  
+- Hybrid and incremental rendering (ISR)  
+- Serverless and edge computing architectures  
+- Micro-frontend architectures
+
+## 3\. Normative References
+
+The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document:
+
+- ISO/IEC 21031:2024 \-- Information technology \-- Software Carbon Intensity (SCI) specification
+
+## 4\. Terms and Definitions
+
+For the purposes of this document, the terms and definitions given in ISO/IEC 21031:2024 and the following apply.
+
+ISO and IEC maintain terminological databases for use in standardization at the following addresses:
+
+- ISO Online browsing platform: available at [https://www.iso.org/obp](https://www.iso.org/obp)  
+- IEC Electropedia: available at [http://www.electropedia.org/](http://www.electropedia.org/)
+
+T.1 **Web Application** Software system that delivers functional value to human users primarily through browser-based interfaces accessed via HTTP/HTTPS protocols, characterized by browser-mediated human interaction
+
+T.2 **Client-Side Energy** Energy consumed by end-user devices (desktops, laptops, tablets, smartphones) during browser rendering, JavaScript execution, and interaction with web application interfaces
+
+T.3 **Server-Side Energy** Energy consumed by origin servers, application servers, database servers, and other backend infrastructure that generates and delivers web application responses
+
+T.4 **Network Transfer Energy** Energy consumed by network infrastructure in transmitting data between servers and end-user devices, including core internet infrastructure, content delivery networks, and last-mile network access
+
+T.5 **Third-Party Service** External service integrated into a web application that is not under direct operational control of the web application provider, including but not limited to: analytics services, advertising networks, authentication providers, payment processors, content delivery networks, and API services
+
+T.6 **Operational Serving** The runtime operation of a web application serving end-user requests, excluding development, testing, and build infrastructure
+
+T.7 **Functional Unit (Web-Specific)** The unit by which a web application's usage scales, measuring delivered functionality such as user sessions, transactions completed, content items consumed, or tasks performed
+
+T.8 **Implementation Tier** The level of measurement sophistication adopted by an organization, ranging from entry-level automated measurement to advanced comprehensive instrumentation
+
+T.9 **Reference Device** A representative end-user device used for standardized client-side energy measurement, selected from defined device categories and performance tiers
+
+T.10 **Energy Displacement** The practice of shifting computation from measured locations to unmeasured locations to improve metrics without reducing total system energy consumption
+
+The following abbreviations are used throughout this specification in addition to those defined in the parent specification:
+
+- **O\_server** \-- Operational emissions from server-side infrastructure (within datacenter boundary)  
+- **O\_network** \-- Operational emissions from network transfer (datacenter egress to client device NIC). OPTIONAL component; see §8.3.  
+- **O\_client** \-- Operational emissions from client-side execution (on end-user devices)  
+- **M\_server** \-- Embodied emissions from server-side hardware and datacenter infrastructure  
+- **M\_network** \-- Embodied emissions from network infrastructure (routers, cell towers, cables, exchange points)  
+- **M\_client** \-- Embodied emissions from end-user devices  
+- **O\_dev** \-- Operational emissions from development lifecycle (optional; see §6.7)  
+- **PUE** \-- Power Usage Effectiveness (datacenter efficiency metric)
+
+Note: O\_thirdparty is not a top-level component. Third-party operational emissions are attributed within O\_server, O\_network, and O\_client based on where execution occurs, with mandatory first-party / third-party sub-dimension disclosure per component (see §6.3.1).
+
+## 5\. Web Application Architecture Components
+
+For the purpose of measuring carbon emissions, a web application system is decomposed into the following components, each contributing to either operational or embodied emissions:
+
+### 5.1 Server-Side Infrastructure
+
+Server-side infrastructure encompasses all backend systems that generate, process, and deliver web application responses. This includes:
+
+- **Origin and application servers**: Systems executing server-side application logic  
+- **Database and storage systems**: Relational databases, NoSQL stores, object storage, caching layers  
+- **Edge and CDN infrastructure**: Content delivery network nodes, edge computing functions, edge caches  
+- **Supporting services**: Load balancers, reverse proxies, API gateways, service mesh, monitoring systems  
+- **Serverless execution environments**: Function-as-a-Service platforms, edge function runtimes
+
+### 5.2 Network Transfer
+
+Network transfer encompasses all data transmission between server infrastructure and end-user devices:
+
+- **Core internet infrastructure**: Backbone and transit networks  
+- **CDN and edge networks**: Content delivery and distribution networks  
+- **Last-mile access**: ISP networks, WiFi, mobile/cellular networks
+
+### 5.3 Client-Side Execution
+
+Client-side execution encompasses all computation occurring on end-user devices:
+
+- **Browser rendering**: Layout, paint, and composite operations  
+- **JavaScript execution**: Parsing, compilation, and runtime execution  
+- **Asset processing**: Image decoding, video playback, font rendering, CSS processing  
+- **Interaction processing**: Event handling, animation, real-time updates  
+- **Service Workers**: Background processing, caching, offline functionality
+
+### 5.4 Third-Party Services
+
+Third-party services encompass external services integrated into the web application:
+
+- **Analytics and monitoring**: Usage tracking, error reporting, performance monitoring  
+- **Advertising networks**: Ad serving, targeting, tracking  
+- **Authentication and identity**: Login, SSO, identity verification  
+- **Payment processing**: Transaction processing, fraud detection  
+- **External APIs**: Data services, AI/ML services, communication services  
+- **Client-side scripts**: Tag managers, chat widgets, social media embeds
+
+Note: Third-party services are not a separate top-level component in the SCI for Web formula. Their energy consumption is attributed within O\_server, O\_network, or O\_client based on where execution occurs, with a mandatory first-party / third-party sub-dimension per component (see §6.3.1).
+
+### 5.5 End-User Devices
+
+End-user devices encompass the hardware on which browsers render and execute web applications:
+
+- **Desktop computers**: Workstations, all-in-one systems  
+- **Laptop computers**: Including Chromebooks and similar  
+- **Smartphones**: All mobile phones with web browsers  
+- **Tablets**: Including hybrid devices
+
+## 6\. Persona-Based Software Boundary Definition
+
+The SCI for Web specification defines measurement responsibilities based on three primary persona groups, each with different spheres of control and agency over the web application's carbon footprint. These personas align with the parent SCI specification's principle that teams should be accountable for elements they can reasonably control or influence.
+
+### 6.1 Frontend Developer Boundary
+
+The Frontend Developer boundary encompasses components where frontend developers and design practitioners have direct control over energy consumption:
+
+- Client-side code efficiency (JavaScript bundle size, execution time)  
+- Asset delivery and optimization (images, fonts, videos, CSS)  
+- Rendering strategies (progressive enhancement, code splitting, lazy loading)  
+- Third-party client-side dependencies (analytics scripts, advertising trackers, external fonts)  
+- User interaction patterns (infinite scroll vs. pagination, auto-playing media)  
+- Browser caching strategies (service workers, cache headers)
+
+**What this boundary measures**: O\_client (including third-party sub-dimension for client-side scripts the frontend developer chose to include), contribution to O\_network (data transferred to client)
+
+**What this boundary excludes**: Server-side infrastructure decisions, database architecture, hosting provider selection, network infrastructure between datacenter and user, end-user device hardware specifications
+
+### 6.2 Backend and Infrastructure Engineer Boundary
+
+The Backend and Infrastructure Engineer boundary encompasses components where backend developers, infrastructure engineers, and DevOps practitioners have direct control:
+
+- Server-side compute and storage resources  
+- Database efficiency and architecture  
+- Geographic hosting location and carbon intensity exposure  
+- Infrastructure capacity relative to actual traffic (right-sizing)  
+- Caching at server and CDN levels  
+- API efficiency and server-side code performance
+
+**What this boundary measures**: O\_server (including third-party sub-dimension for server-side API dependencies), M\_server, contribution to O\_network (server-side network configuration)
+
+**What this boundary excludes**: End-user device choices, browser vendor implementations, client-side third-party script behavior (though controls whether to include them)
+
+### 6.3 Product Owner and Technical Manager Boundary
+
+The Product Owner and Technical Manager boundary encompasses strategic and architectural decisions:
+
+- Feature prioritization and lifecycle management ("feature gardening")  
+- Performance and environmental budget setting  
+- Vendor selection and third-party service decisions  
+- Team time allocation for optimization  
+- Architectural standards and patterns  
+- Non-functional requirements including sustainability targets
+
+**What this boundary influences**: All components (O\_server, O\_network, O\_client, M\_server, M\_network, M\_client) through architectural decisions and prioritization, including third-party service selection whose emissions appear as sub-dimensions within the appropriate operational component (see §6.3.1)
+
+**What this boundary excludes**: Day-to-day implementation details, supplier internal implementations, end-user behavior and device choices
+
+### 6.3.1 First-Party vs Third-Party Attribution
+
+Client-side energy consumption includes all execution on the end-user device, regardless of script origin. This includes first-party application code (the organization's own JavaScript, WASM, rendering logic), third-party scripts executing in the browser (analytics, advertising, chat widgets, embedded media), and hybrid execution (first-party code invoking third-party libraries).
+
+Energy is attributed to the decision maker who introduced the dependency, not the legal entity providing the code:
+
+- Frontend developer includes analytics widget → O\_client (third-party sub-dimension)  
+- Backend developer integrates payment API → O\_server (third-party sub-dimension)  
+- Infrastructure team selects CDN provider → O\_network (third-party sub-dimension)  
+- User installs browser extension → Not attributed to the web application
+
+Client-side third-party execution is measurable using Long Task API for JavaScript execution time by origin, Resource Timing API for third-party asset loading, JavaScript profiling in browser DevTools, and Real User Monitoring (RUM) tools with script attribution. Where direct attribution is impractical, organizations may estimate using script bundle sizes with disclosed estimation methodology.
+
+O\_client MUST be reported with first-party / third-party breakdown:
+
+- O\_client\_first: Energy from the organization's own client-side code  
+- O\_client\_third: Energy from third-party scripts executing in the browser  
+- Total: O\_client = O\_client\_first + O\_client\_third
+
+Organizations unable to separate first-party and third-party client execution MUST disclose this limitation and report blended O\_client with "attribution: undifferentiated."
+
+The same first-party / third-party sub-dimension applies to O\_server and O\_network, disclosed even if one side is zero or not separately measurable.
+
+### 6.4 Consolidated Software Boundary
+
+While persona boundaries define responsibility and agency, the SCI for Web score is calculated across the **consolidated software boundary** encompassing all components:
+
+**Mandatory inclusions**:
+
+- Server-side infrastructure (origin servers, databases, caching, serverless functions, edge nodes, load balancers, API gateways)  
+- Network transfer (all data transmitted between server infrastructure and end-user devices across all network segments)  
+- Client-side execution (browser rendering, JavaScript execution, asset processing on end-user devices)  
+- End-user devices (embodied emissions allocated proportionally to web application usage)  
+- Third-party services (external services providing integral functionality)
+
+**Optional inclusions with disclosure**:
+
+- Content Delivery Networks operated or contracted by the web application provider  
+- Monitoring and observability infrastructure (if significantly contributing to energy consumption)  
+- Redundancy and failover systems (idle failover infrastructure)
+
+**Explicit exclusions**:
+
+- Development and build infrastructure (developer workstations, CI/CD pipelines, build processes, automated testing, staging environments) \-- to avoid perverse incentives discouraging essential development practices  
+- Post-delivery artifacts (email delivery after send, file downloads after transfer, offline processing triggered independently)  
+- Native mobile applications (even those using WebViews)  
+- Browser extensions, plugins, or assistive technologies
+
+*Rationale for development exclusion*: Measuring development infrastructure within SCI for Web would create perverse incentives to reduce testing, security scanning, and quality assurance. Development lifecycle energy may be measured separately using the parent SCI methodology.
+
+### 6.7 Development Lifecycle Operational Emissions (O\_dev) — Optional
+
+O\_dev captures operational energy consumed during software development activities: CI/CD pipelines, build processes, automated testing, development environment operation, and version control infrastructure.
+
+O\_dev is not required for baseline SCI for Web compliance but is explicitly recognized as a valid supplementary component for organizations seeking comprehensive lifecycle accounting. Including O\_dev acknowledges that development is the lifecycle stage where teams have direct measurement control, that pre-deployment energy is attributable to specific software artifacts, and that optimization incentives exist (faster builds, efficient CI/CD, targeted testing).
+
+Organizations including O\_dev should define clear boundaries (e.g., from commit to deployment artifact creation), allocate development energy to deployed features proportionally (e.g., by time-to-market or feature complexity), declare measurement methodology and tooling used, and report O\_dev separately from the six mandatory components to maintain comparability.
+
+When including O\_dev, organizations must define how development energy amortizes over the functional unit. Example approaches include allocating evenly across all instances of R during a deployment period, weighting by feature usage if development was feature-specific, or amortizing over expected feature lifetime.
+
+## 7\. Functional Units
+
+### 7.1 General Guidance
+
+The functional unit (R) for a web application SHALL describe how the application scales and delivers value to users. Following the parent specification, R SHALL be consistent across all components in the software boundary.
+
+For web applications, functional units SHALL measure **delivered functionality** rather than **technical operations**. This prevents gaming through quality degradation and ensures SCI scores reflect efficiency of value delivery.
+
+Web applications MAY define **multiple functional units** representing distinct value-delivery pathways. Complex applications SHOULD define multiple FUs when the application serves distinctly different user journeys or when features have substantially different resource intensities. Each functional unit has its own SCI score. There is no requirement to reduce complex applications to a single headline number.
+
+Comparability across functional units operates at two levels: per-FU comparability (e.g., "purchase completed" SCI is comparable across e-commerce sites) and maturity comparability (organizations tracking more sophisticated FUs demonstrate deeper SCI integration). Comparability weakens as functional units become more application-specific; this is expected and acceptable.
+
+### 7.2 Recommended Functional Units by Application Type
+
+The table below provides suggested examples of commonly used functional units. Given the diversity of web application types and usage models, these examples are indicative and not exhaustive.
+
+| Web Application Type | Suggested Functional Unit | Rationale |
+| :---- | :---- | :---- |
+| Content and media websites | Content item consumed (article read, video watched) | Captures delivered value; resistant to page-splitting gaming |
+| E-commerce platforms | Completed transaction | Aligns with business value delivery; scales with actual usage |
+| SaaS applications | Task completion (document created, report generated) | Measures delivered functionality, not login frequency |
+| Collaboration tools | Active collaboration session or user-hour | Captures sustained engagement and value delivery |
+| API-driven applications with browser UI | User workflow completed | Measures end-to-end value, not individual API calls |
+| Marketing and informational websites | User session (with engagement threshold) | Appropriate for content consumption patterns |
+| Real-time applications | Active user-minute | Captures ongoing resource consumption proportionally |
+
+### 7.3 Functional Unit Selection Criteria
+
+When selecting a functional unit, organizations SHALL consider:
+
+1. **Scaling relationship**: The functional unit SHOULD scale proportionally with resource consumption  
+2. **User value alignment**: The functional unit SHOULD represent delivered value, not technical implementation details  
+3. **Measurability**: The functional unit SHALL be objectively measurable from analytics or instrumentation  
+4. **Stability**: The functional unit definition SHOULD remain stable over time to enable comparison  
+5. **Gaming resistance**: The functional unit SHOULD NOT incentivize reducing functionality or quality
+
+### 7.4 Discouraged Functional Units
+
+The following functional units SHOULD generally be avoided:
+
+- **Raw page views**: Does not account for page complexity or user value delivered  
+- **API calls**: Technical metric easily gamed by consolidating or splitting calls  
+- **Data transferred**: Incentivizes reducing content quality rather than improving efficiency  
+- **Server requests**: Backend technical metric disconnected from user value
+
+Exceptions may exist when these metrics genuinely represent delivered value. If used, justification SHALL be disclosed.
+
+### 7.5 Reporting Expectations
+
+Organizations SHALL clearly state:
+
+- The chosen functional unit and the rationale behind its selection  
+- How the functional unit is measured (analytics instrumentation, server logs, etc.)  
+- Any engagement thresholds applied (e.g., minimum session duration for "user session")  
+- How the functional unit relates to the application's primary value delivery
+
+### 7.6 Bot Traffic and Non-Human Access
+
+Bot traffic and non-human access SHALL be handled based on detection capability:
+
+- **Preferred approach**: Separate functional units for human and non-human traffic (e.g., R\_human for "human page view", R\_bot for "bot page view" or "automated API access"), each with its own SCI score  
+- **Combined reporting**: Acceptable when reliable human/non-human separation is not feasible; reported as combined FU with disclosure of detection limitations and estimated bot proportion  
+- **Exclusion**: Permitted only with reliable detection, justification (e.g., malicious bot traffic), and disclosure of exclusion methodology
+
+Organizations MUST disclose: whether bot traffic is included, excluded, or reported separately; what detection method was used; and estimated bot proportion of total traffic. Neither inclusion nor exclusion of bot traffic is inherently correct — comparability comes from transparency.
+
+Engagement thresholds (e.g., minimum 30-second session duration, at least one interaction event) are set by the organization and disclosed. No universal session threshold is mandated, as legitimate session shapes vary too widely across application types. Examples given in this specification are illustrative only and SHOULD NOT be treated as informal defaults — organizations SHALL select thresholds that reflect their actual user-behaviour patterns (a 30-second minimum is inappropriate for marketing or content-discovery sites with legitimately short sessions, for example).
+
+## 8\. Methodology
+
+### 8.1 General Formula
+
+SCI for Web extends the parent specification formula to explicitly decompose web-specific operational and embodied components:
+
+`SCI = (O + M) per R`
+
+Where for web applications, O is decomposed as:
+
+`O = O_server + O_client  [+ O_network, optional — see §8.3]`
+
+And M is decomposed as:
+
+`M = M_server + M_network + M_client`
+
+Therefore, the mandatory SCI for Web formula is:
+
+`SCI = (O_server + O_client + M_server + M_network + M_client) per R`
+
+Organizations MAY additionally include O\_network when a defensible methodology is available (see §8.3). When included, the reported SCI score becomes:
+
+`SCI (with O_network) = (O_server + O_network + O_client + M_server + M_network + M_client) per R`
+
+Where:
+
+- `O_server` \= Operational emissions from server-side infrastructure (within datacenter boundary)  
+- `O_network` \= Operational emissions from network transfer (datacenter egress to client device NIC). OPTIONAL — see §8.3 for rationale and methodology requirements.  
+- `O_client` \= Operational emissions from client-side execution on end-user devices (including third-party scripts; see §6.3.1)  
+- `M_server` \= Embodied emissions from server-side hardware  
+- `M_network` \= Embodied emissions from network infrastructure (see §8.8)  
+- `M_client` \= Embodied emissions from end-user device hardware  
+- `R` \= Functional unit measuring delivered value
+
+**Why O\_network is optional**: Operational network emissions are currently difficult to measure defensibly. Widely-used estimation approaches based on bytes-transferred (e.g., SWDM) are acknowledged proxies that can produce misleading results by incentivising apparent efficiency improvements (compression, smaller assets) that do not correspond to reductions in actual network energy use. Rather than mandate a known-weak methodology that could discredit SCI for Web scores, this specification requires reporting without O\_network as the baseline, and permits O\_network inclusion as a supplementary disclosure when methodology supports it. Embodied network emissions (M\_network) remain mandatory because they are structurally present regardless of traffic patterns.
+
+Organizations SHALL disclose whether O\_network was included or omitted from their reported SCI for Web score, and if included, the methodology used (see §8.3 and §12.1).
+
+Third-party operational emissions are attributed within O\_server and O\_client (and within O\_network where reported) based on where execution occurs, with mandatory first-party / third-party sub-dimension disclosure (see §6.3.1).
+
+Organizations MAY additionally report O\_dev (development lifecycle emissions) as a supplementary component (see §6.7). When reported, O\_dev is disclosed separately and does not alter the mandatory formula above.
+
+Each operational component follows the pattern `O = E * I` from the parent specification, where E is energy consumed in kWh and I is location-based carbon intensity in gCO2eq/kWh.
+
+### 8.2 Server-Side Operational Emissions (O\_server)
+
+`O_server = E_server * I_server`
+
+Where:
+
+- `E_server` \= Energy consumed by all server-side infrastructure per functional unit (kWh)  
+- `I_server` \= Carbon intensity of electricity consumed by server infrastructure (gCO2eq/kWh)
+
+**Energy (E\_server)** includes energy consumed by:
+
+- Origin servers and application servers  
+- Database servers and caching infrastructure  
+- Serverless function execution environments  
+- Edge computing nodes (CDN edge servers, edge functions)  
+- Supporting infrastructure (load balancers, firewalls, monitoring systems)
+
+Energy consumption SHALL include all energy consumed by hardware reserved or provisioned for the web application, including idle resources, following the parent specification guidance.
+
+If servers are located in datacenters, energy measurements SHALL account for datacenter efficiency by incorporating Power Usage Effectiveness (PUE):
+
+`E_server = E_compute * PUE`
+
+For multi-tenant infrastructure (shared hosting, cloud computing), energy SHALL be attributed based on resource allocation (vCPUs, memory, storage) proportional to total capacity.
+
+For geographically distributed server infrastructure:
+
+`E_server = SUM(E_region_i)` for all regions i
+
+**Carbon Intensity (I\_server)**: For geographically distributed systems, carbon intensity SHALL be calculated as an energy-weighted average:
+
+`I_server = SUM(E_region_i * I_region_i) / SUM(E_region_i)`
+
+Carbon intensity values SHALL use location-based grid carbon intensity, excluding any market-based measures per the parent specification.
+
+### 8.3 Network Transfer Operational Emissions (O\_network)
+
+**Status**: O\_network is an OPTIONAL component of the SCI for Web score. The mandatory formula (see §8.1) excludes O\_network. Organizations MAY additionally report O\_network as a supplementary disclosure when a defensible methodology is available.
+
+**Why optional**: Operational network emissions are currently difficult to measure defensibly. The most widely-used estimation approaches allocate energy based on bytes transferred, which is an acknowledged-weak proxy for actual network energy consumption. Including a mandatory component whose methodology is known to produce misleading results risks discrediting the overall SCI for Web score. This specification therefore separates the reliably-measurable components (O\_server, O\_client, M\_server, M\_network, M\_client) from the harder-to-measure O\_network, and permits but does not require the latter.
+
+**If reported**, O\_network is calculated as:
+
+`O_network = E_network * I_network`
+
+Where:
+
+- `E_network` \= Energy consumed by network infrastructure to transfer data per functional unit (kWh)  
+- `I_network` \= Carbon intensity of electricity consumed by network infrastructure (gCO2eq/kWh)
+
+**Methodology hierarchy (when O\_network is reported)**:
+
+Organizations SHALL use the most direct method available and SHALL NOT use bytes-transferred as the sole basis of calculation except as a last-resort fallback with explicit disclosure.
+
+**Preferred — Direct Measurement**: Where instrumentation is available (e.g., ISP or CDN partner supplying measured energy data for the traffic attributable to the application), direct measurement SHALL be used.
+
+**Acceptable — Hybrid Model**: A calculation combining measured or vendor-disclosed network segment data (e.g., last-mile operator energy reports) with modelled remainder. Organizations using this approach SHALL disclose which segments are measured versus modelled, and the rationale for any modelling coefficients.
+
+**Fallback — Data-Transfer Estimation**: Bytes-transferred proxies (e.g., SWDM, CO2.js coefficients) MAY be used only when no measurement or hybrid approach is available. Organizations using this fallback SHALL disclose: (a) the model and coefficients used, (b) that bytes-transferred is an acknowledged-weak proxy for network energy, (c) why more direct methods were not available, and (d) that the reported O\_network value carries high methodological uncertainty.
+
+**Data transfer measurement** (when used) SHALL include all bytes transferred between server infrastructure and end-user devices, including HTML, CSS, JavaScript, images, videos, fonts, API responses and request bodies, WebSocket and real-time protocols, and HTTP headers and protocol overhead. Data SHALL be measured at the application layer after compression.
+
+**Gaming guard**: Organizations using bytes-transferred fallback methods SHOULD NOT report reductions in O\_network as the primary narrative for efficiency improvements, because bytes-reduction can occur without corresponding network energy reduction (e.g., edge caching shifts energy rather than eliminating it). This aligns with the parent SCI specification's principle that SCI reductions must reflect actual emission reductions, not accounting shifts.
+
+**Preventing Double-Counting with CDN and Edge Services**:
+
+The boundary between O\_server and O\_network occurs at datacenter facility egress. CDN and edge services energy is attributed based on measurement regime, not service type:
+
+1. If measured as facility energy (edge datacenter with PUE, metered infrastructure): include in O\_server  
+2. If measured as transmission energy (traffic-based, SWDM-style allocation): include in O\_network  
+3. If bundled by provider without clear separation: organizations MUST disclose which component received the allocation and why
+
+When a provider supplies bundled energy figures, practitioners MUST document which SCI components received portions of the bundled figure, what allocation rationale was used, and what assumptions about measurement regime justified the split.
+
+**Connection-Type Weighting**: Mobile radio access networks consume roughly an order of magnitude more energy per bit than fiber connections. SWDM default coefficients provide blended averages. Entry Tier organizations may use default SWDM coefficients. Standard and Advanced Tier organizations SHOULD apply connection-type weighting when user traffic distribution is known. Connection-type weighting is encouraged but not mandatory; disclosure of whether weighting was applied is mandatory.
+
+**SWDM Double-Counting Rule**: When using SWDM, use ONLY the network segment for O\_network. Discard SWDM's datacenter and device allocations, replacing them with direct measurement for O\_server and O\_client. SWDM allocates a single system energy total across three segments; taking network from SWDM and server/client from direct measurement avoids summing overlapping allocations. Organizations using SWDM for O\_network MUST disclose the SWDM version and coefficients used, whether connection-type weighting was applied, how edge facility energy was handled, and known limitations.
+
+**Preventing Double-Counting with CDN and Edge Services**:
+
+The boundary between O\_server and O\_network occurs at datacenter facility egress. CDN and edge services energy is attributed based on measurement regime, not service type:
+
+1. If measured as facility energy (edge datacenter with PUE, metered infrastructure): include in O\_server  
+2. If measured as transmission energy (traffic-based, SWDM-style allocation): include in O\_network  
+3. If bundled by provider without clear separation: organizations MUST disclose which component received the allocation and why
+
+When a provider supplies bundled energy figures, practitioners MUST document which SCI components received portions of the bundled figure, what allocation rationale was used, and what assumptions about measurement regime justified the split.
+
+*Illustrative bundled-allocation example (non-normative)*: A CDN provider publishes a single "CDN total energy for your traffic = 42 kWh/month" figure. An application that uses the CDN for static asset delivery and edge functions may allocate this using a cache-hit-ratio split: if 70% of requests are cache hits served without origin compute, attribute 70% of the 42 kWh to O\_network (transmission) and 30% to O\_server (edge compute). The operator discloses: the allocation rule, the ratio sources (CDN analytics), and a note that if the CDN publishes component-specific figures in future, the allocation will switch to those.
+
+**Connection-Type Weighting**: Mobile radio access networks consume roughly an order of magnitude more energy per bit than fiber connections. SWDM default coefficients provide blended averages. Entry Tier organizations may use default SWDM coefficients. Standard and Advanced Tier organizations SHOULD apply connection-type weighting when user traffic distribution is known. Connection-type weighting is encouraged but not mandatory; disclosure of whether weighting was applied is mandatory.
+
+**SWDM Double-Counting Rule**: When using SWDM, use ONLY the network segment for O\_network. Discard SWDM's datacenter and device allocations, replacing them with direct measurement for O\_server and O\_client. SWDM allocates a single system energy total across three segments; taking network from SWDM and server/client from direct measurement avoids summing overlapping allocations. Organizations using SWDM for O\_network MUST disclose the SWDM version and coefficients used, whether connection-type weighting was applied, how edge facility energy was handled, and known limitations.
+
+### 8.4 Client-Side Operational Emissions (O\_client)
+
+`O_client = E_client * I_client`
+
+Where:
+
+- `E_client` \= Energy consumed by end-user devices for browser rendering and execution per functional unit (kWh)  
+- `I_client` \= Carbon intensity of electricity consumed by end-user devices (gCO2eq/kWh)
+
+**Energy (E\_client)** includes:
+
+- Browser rendering engine (layout, paint, composite)  
+- JavaScript execution (parsing, compilation, runtime)  
+- CSS processing and style calculation  
+- Asset decoding (images, videos, audio)  
+- User interaction processing  
+- Service Worker execution
+
+Organizations SHALL measure client-side energy using one of the following approaches (aligned with implementation tiers):
+
+**Tier 1 \-- Reference Device Testing**: Measure energy consumption on reference devices representing the user base using browser profiling tools. Report device types and models used.
+
+**Tier 2 \-- Device Mix Weighted Average**: Measure energy across multiple device categories (desktop, laptop, tablet, mobile), weighted by actual device distribution from analytics data.
+
+**Tier 3 \-- Real User Monitoring**: Instrument browsers to collect energy consumption telemetry from actual users. Privacy-preserving sampling and anonymization required.
+
+**Carbon Intensity (I\_client)**: Organizations SHALL use one of:
+
+- **User-location-based**: Weighted average grid carbon intensity based on user geographic distribution  
+- **Conservative estimate**: High percentile (e.g., 75th percentile) of global grid carbon intensity  
+- **Disclosed assumption**: Global average grid carbon intensity with clear disclosure
+
+### 8.5 Third-Party Service Attribution
+
+Third-party operational emissions are not a separate top-level component. Instead, they are attributed within O\_server, O\_network, and O\_client based on where execution occurs (see §6.3.1 for the attribution framework).
+
+Organizations SHALL account for third-party services using one of the following estimation approaches within the appropriate component:
+
+**Method A \-- Vendor Disclosure**: Use energy and carbon intensity data published by the vendor. Attribute to the component where execution occurs. Disclose vendor, data source, and date.
+
+**Method B \-- API Call Estimation**: For server-side API-based services, estimate energy as: `E_service = API_calls * E_per_call` where E\_per\_call is either vendor-disclosed or an industry default value. Attribute to O\_server (third-party sub-dimension). Disclose estimation methodology and coefficients.
+
+**Method C \-- Client-Side Script Estimation**: For third-party scripts executing in the browser, estimate based on script execution time (Long Task API), data transferred, and resource consumption. Attribute to O\_client (third-party sub-dimension). Disclose methodology and limitations.
+
+Organizations SHALL disclose which third-party services are measured, estimated, or excluded, and in which component they are attributed. Services contributing less than 1% of total estimated energy MAY be excluded but SHALL be listed in limitations disclosure.
+
+### 8.6 Server-Side Embodied Emissions (M\_server)
+
+Following the parent SCI specification:
+
+`M_server = TE_server * TS_server * RS_server`
+
+Where:
+
+- `TE_server` \= Total embodied emissions of server-side hardware (gCO2eq)  
+- `TS_server` \= Time-share: proportion of hardware lifespan reserved for this web application  
+- `RS_server` \= Resource-share: proportion of hardware resources reserved for this web application
+
+Expanded:
+
+`M_server = TE_server * (TiR_server / EL_server) * (RR_server / ToR_server)`
+
+For cloud infrastructure where physical hardware details are unavailable, organizations MAY use instance type specifications and embodied emissions databases (e.g., Boavizta, Cloud Carbon Footprint), virtual resource allocation as proxy for resource-share, or cloud provider embodied emissions data if disclosed.
+
+### 8.7 Client-Side Embodied Emissions (M\_client)
+
+`M_client = SUM(TE_device_type * TS_device_type * RS_device_type)` for each device type
+
+Where for each device type (desktop, laptop, tablet, smartphone):
+
+- `TE_device_type` \= Total embodied emissions for that device type (gCO2eq)  
+- `TS_device_type` \= Time-share: proportion of device lifespan used for this web application  
+- `RS_device_type` \= Resource-share: proportion of device resources used during usage time
+
+**Time-share**: For a user session of duration D (hours) with device expected lifespan EL\_device (hours): `TS_device_type = D / EL_device`
+
+**Resource-share**: Estimated as average CPU utilization during web application usage relative to total device active time.
+
+**Device type distribution**: Organizations SHALL determine device mix using actual analytics data showing device type distribution, or industry default distribution with disclosure.
+
+**Default embodied emissions values** (organizations MAY use more specific data if available):
+
+| Device Type | Embodied Emissions | Expected Lifespan |
+| :---- | :---- | :---- |
+| Desktop computer | 400 kg CO2eq | 5 years |
+| Laptop computer | 300 kg CO2eq | 4 years |
+| Tablet | 100 kg CO2eq | 4 years |
+| Smartphone | 80 kg CO2eq | 3 years |
+
+Organizations using defaults SHALL disclose this choice. Organizations with access to device-specific lifecycle analysis data SHOULD use those values.
+
+### 8.8 Network Infrastructure Embodied Emissions (M\_network)
+
+M\_network captures embodied carbon in network infrastructure hardware: routers, switches, cell towers, undersea cables, internet exchange points, and edge points of presence.
+
+**Status**: M\_network is structurally required as a top-level component to ensure completeness and prevent silent exclusion of material emissions. However, allocation of global network embodied carbon to individual web applications presents practical challenges.
+
+**Allocation basis (important)**: Bytes-transferred (data volume) is NOT an acceptable basis for allocating M\_network to an individual web application. Network hardware embodied carbon does not meaningfully scale with the amount of data an application sends — it scales with deployment footprint, user count, connection sessions, coverage area, and hardware lifespan. Allocating by data volume creates an incentive structure where apparent reductions in file size correspond to a paper reduction in M\_network that does not reflect any real reduction in embodied hardware emissions. This mirrors the rationale for excluding bytes-transferred as the mandatory basis for O\_network in §8.3.
+
+Valid allocation bases follow the parent SCI embodied pattern `M = TE * TS * RS`, where TS is time-share of hardware lifespan and RS is resource-share of hardware capacity. Practical proxies that fit this pattern include active user-sessions, user-hours, concurrent-connection-hours, or vendor-supplied allocation; bytes transferred does not fit this pattern.
+
+**Tier-Based Implementation**:
+
+- **Entry Tier**: May declare M\_network as "unpopulated — insufficient allocation methodology" with documented rationale  
+- **Standard Tier**: Should apply industry-default embodied factors (e.g., Boavizta network hardware defaults) using an operator-disclosed non-bytes allocation methodology — for example, active user-sessions, user-hours, or vendor-supplied allocation. Assumptions and the chosen allocation basis MUST be disclosed. Bytes-transferred is not an acceptable allocation basis.  
+- **Advanced Tier**: Should seek vendor-specific embodied data for major network providers (ISP, CDN, mobile operator) where available. Where vendors publish their own allocation methodology, organizations MAY adopt it with disclosure.
+
+**Materiality Threshold**: Organizations MAY omit M\_network population only after documented materiality analysis showing network embodied emissions contribute less than 5% of total embodied emissions (M\_server + M\_network + M\_client). For network-intensive applications (streaming, real-time collaboration, large file transfer), M\_network is presumed material unless analysis demonstrates otherwise.
+
+**Mandatory Disclosure**: Even when M\_network is unpopulated, organizations MUST disclose: why allocation was deemed impractical or immaterial, what data sources were evaluated, whether the application profile is network-intensive, and a commitment to revisit as allocation methodologies improve. An unpopulated-M\_network declaration SHOULD be revisited at least annually. For network-intensive applications, annual review is REQUIRED.
+
+## 9\. Implementation Tiers
+
+Organizations SHALL select one of three implementation tiers based on measurement sophistication and data availability. All tiers are legitimate when methodology is transparently disclosed.
+
+### 9.1 Entry Tier
+
+**Target users**: Teams beginning SCI for Web adoption with limited measurement infrastructure.
+
+**Requirements**:
+
+- Automated measurement using freely available tools  
+- Direct measurement of server-side energy (cloud provider APIs, infrastructure monitoring)  
+- Reference device measurement of client-side energy (minimum 1 device per major category)  
+- Industry default coefficients for network energy  
+- Third-party services estimated using conservative defaults or excluded with disclosure  
+- Measurement period minimum 7 consecutive days of representative traffic  
+- Full disclosure of methodology, tools, and limitations
+
+**Acceptable data sources**:
+
+- Cloud provider energy/carbon APIs  
+- Browser developer tools for client-side profiling  
+- Sustainable Web Design Model for network energy  
+- Default embodied emissions values from this specification  
+- Industry default third-party service coefficients
+
+### 9.2 Standard Tier
+
+**Target users**: Teams with established measurement practice seeking improved accuracy.
+
+**Requirements**:
+
+- Direct measurement of server-side and client-side energy across representative scenarios  
+- Device-mix-weighted client-side measurements (minimum 2 devices per major category)  
+- Network energy calculated using validated model (SWDM or equivalent)  
+- Third-party services included using vendor data or documented estimation methodology  
+- Carbon intensity calculated with daily granularity minimum  
+- Measurement period minimum 30 consecutive days or representative business cycle  
+- Validation of accuracy against published benchmarks where available  
+- Comprehensive disclosure of methodology, data sources, and uncertainty
+
+**Acceptable data sources**:
+
+- Infrastructure instrumentation and telemetry  
+- Browser profiling across device types  
+- Network traffic analysis and modeling  
+- Third-party vendor disclosure or API-based estimation  
+- Regional grid carbon intensity databases (ElectricityMaps, WattTime, etc.)
+
+### 9.3 Advanced Tier
+
+**Target users**: Organizations with sophisticated measurement capabilities and sustainability commitments.
+
+**Requirements**:
+
+- Continuous measurement infrastructure for server-side and network components  
+- Real user monitoring (RUM) for client-side energy with statistical sampling  
+- Comprehensive third-party service inclusion with vendor engagement  
+- Carbon intensity calculated with hourly granularity enabling carbon-aware optimization  
+- Geographic and temporal carbon intensity distribution  
+- Continuous measurement with regular reporting (monthly/quarterly)  
+- Independent validation or audit of methodology  
+- Public disclosure of methodology, data sources, and results  
+- Embodied emissions using device-specific lifecycle analysis where available
+
+### 9.4 Quantification Method by Tier
+
+Organizations SHALL disclose for each component whether measurement or calculation was used:
+
+| Component | Entry Tier | Standard Tier | Advanced Tier |
+| :---- | :---- | :---- | :---- |
+| O\_server | Measurement or calculation | Measurement preferred | Continuous measurement |
+| O\_network (optional) | Not reported, or data-transfer fallback with disclosure | Hybrid or direct measurement where available; data-transfer fallback only if no alternative | Direct measurement or hybrid model; data-transfer fallback strongly discouraged |
+| O\_client | Measurement (reference devices) | Measurement (device mix) | Measurement (RUM) |
+| M\_server | Calculation (defaults or LCA) | Calculation (LCA databases) | Calculation (specific LCA) |
+| M\_network | Unpopulated with disclosure | Calculation (industry defaults) | Calculation (vendor-specific) |
+| M\_client | Calculation (defaults) | Calculation (device-specific) | Calculation (device-specific LCA) |
+| O\_dev (optional) | Calculation if included | Measurement if included | Measurement if included |
+
+Note: Third-party operational emissions are reported as sub-dimensions within O\_server, O\_network, and O\_client (see §6.3.1), not as a separate component row.
+
+## 10\. Procedure
+
+The steps required to calculate and report an SCI for Web score extend the parent specification procedure:
+
+1. **Select Implementation Tier**: Choose Entry, Standard, or Advanced tier based on organizational capability and measurement sophistication goals (see Section 9).  
+     
+2. **Bound**: Decide on the software boundary; i.e., the components of the web application system to include. For web applications, this SHALL include at minimum: server-side infrastructure, network transfer, client-side execution, and end-user devices (see Section 6.4).  
+     
+3. **Scale**: Pick the functional unit which best describes how the application scales and delivers value to users. For web applications, this SHOULD measure delivered functionality rather than technical operations (see Section 7).  
+     
+4. **Define**: For each software component listed in the software boundary, decide on the quantification method: direct measurement using instrumentation and telemetry, or calculation using models and industry defaults (see Section 9.4).  
+     
+5. **Quantify**: Calculate a rate for every software component. The SCI for Web value of the whole application is the sum of the component values.  
+     
+6. **Report**: Disclose the SCI for Web score, implementation tier, software boundary, functional unit, calculation methodology, data sources, and limitations following the disclosure requirements (see Section 12).
+
+## 11\. Implementation Examples
+
+This section provides examples of how to apply the SCI for Web specification in real-world scenarios.
+
+### 11.1 E-Commerce Platform Example
+
+For a typical e-commerce web application, an SCI for Web score is calculated as follows:
+
+**Functional Unit**: Completed transaction
+
+**Boundary**: Server-side infrastructure (application servers, database, CDN edge), network transfer, client-side execution, third-party services (payment processor, analytics), end-user devices
+
+**Calculation Method**:
+
+1. Measure all mandatory operational and embodied carbon within the software boundary over a defined period (e.g., 30 days):  
+   - O\_server: Energy consumed by application servers, databases, and CDN edge nodes, multiplied by regional carbon intensity. Third-party API calls to payment processor included under O\_server (third-party sub-dimension).  
+   - O\_client: Client-side energy per transaction measured on reference devices, multiplied by user-location-weighted carbon intensity. Analytics script execution included under O\_client (third-party sub-dimension).  
+   - M\_server, M\_network, M\_client: Embodied emissions allocated per §8.6–§8.8  
+2. Optionally: report O\_network separately when a defensible methodology is available (see §8.3). In this example the organisation has chosen not to report O\_network because no direct measurement is available and they prefer not to rely on bytes-transferred estimates.  
+3. Sum all included components to get total carbon (C)  
+4. Count total completed transactions during the period (R)  
+5. Calculate: `SCI = C / R`
+
+**Example (mandatory components only)**:
+
+- O\_server: 2,100 kg CO2eq/month (includes third-party API, 90 kg sub-dimension)  
+- O\_client: 890 kg CO2eq/month (includes third-party scripts, 120 kg sub-dimension)  
+- M\_server: 320 kg CO2eq/month  
+- M\_network: 40 kg CO2eq/month (Boavizta defaults, industry average)  
+- M\_client: 150 kg CO2eq/month  
+- Total C: 3,500 kg CO2eq/month  
+- Total completed transactions (R): 500,000/month  
+- **SCI = 7.00 g CO2eq per completed transaction**
+
+The organisation has disclosed that O\_network is not included in the reported score and provides rationale in the limitations section.
+
+### 11.2 Content/Media Website Example
+
+For a news or media website:
+
+**Functional Unit**: Content item consumed (article read)
+
+**Boundary**: Server-side (application servers, CMS, CDN), network transfer, client-side execution, third-party services (analytics, advertising), end-user devices
+
+**Example**:
+
+- Total C: 1,250 kg CO2eq/month  
+- Total articles read (with engagement threshold of 30+ seconds): 2,000,000/month  
+- **SCI \= 0.63 g CO2eq per article read**
+
+### 11.3 SaaS Application Example
+
+For a project management SaaS application:
+
+**Functional Unit**: Active user session (minimum 5 minutes engagement)
+
+**Boundary**: Server-side (application servers, database, real-time messaging infrastructure), network transfer, client-side execution, third-party services (authentication, email notification API), end-user devices
+
+**Example**:
+
+- Total C: 4,600 kg CO2eq/month  
+- Total active user sessions: 150,000/month  
+- **SCI \= 30.7 g CO2eq per active user session**
+
+### 11.4 Reporting
+
+For the e-commerce example above, the following should be reported:
+
+- **SCI for Web Score**: 7.00 g CO2eq per completed transaction  
+- **Implementation Tier**: Standard  
+- **Software Boundary**: Application servers (AWS eu-west-1), PostgreSQL database, CloudFront CDN, client-side React application, Stripe payment API, Google Analytics  
+- **O\_network Inclusion**: Excluded from score. No direct or vendor-disclosed network energy data available; organisation chose not to use bytes-transferred fallback due to acknowledged methodological weakness. Will revisit when CDN partner publishes measured energy data.  
+- **Functional Unit**: Completed transaction (checkout flow resulting in order confirmation)  
+- **Measurement Period**: 2026-01-01 to 2026-01-31 (31 days), average 16,100 transactions/day  
+- **Component Breakdown**: O\_server 60% (including 2.6% third-party), O\_client 25% (including 3.4% third-party), M\_server 9%, M\_client 4%, M\_network 1%  
+- **Quantification Methods**: O\_server measured via AWS Carbon Footprint Tool (Stripe API estimated via Method B, attributed as O\_server third-party sub-dimension); O\_client measured on 6 reference devices weighted by analytics device mix (Google Analytics script execution estimated via Method C, attributed as O\_client third-party sub-dimension); M\_network calculated using Boavizta network hardware defaults proportional to data volume  
+- **Carbon Intensity**: ElectricityMaps daily average for eu-west-1; global average for client-side  
+- **Limitations**: O\_network not reported (see above); third-party analytics client-side energy partially estimated; mobile device measurements limited to 2 models
+
+## 12\. Disclosure Requirements
+
+### 12.1 Mandatory Disclosures
+
+Organizations reporting SCI for Web scores SHALL disclose:
+
+1. **SCI for Web Score**: The calculated value with units (gCO2eq per \[functional unit\])  
+2. **Implementation Tier**: Entry, Standard, or Advanced  
+3. **Software Boundary**: Complete description of included and excluded components  
+4. **O\_network Inclusion**: Whether O\_network was included in the reported score. If included, the methodology used (direct measurement, hybrid, or data-transfer fallback) and known limitations. If excluded, this SHALL be stated explicitly.  
+5. **Functional Unit**: Definition of R with justification for selection  
+6. **Measurement Period**: Start date, end date, duration, and traffic characterization  
+7. **Quantification Methods**: For each mandatory component (O\_server, O\_client, M\_server, M\_network, M\_client) and for O\_network if reported:  
+   - Measurement or calculation approach  
+   - Tools and instrumentation used  
+   - Data sources (including third-party data providers)  
+   - Coefficients and constants used  
+   - Estimation methodologies where measurement unavailable  
+8. **First-party / Third-party Breakdown**: For each operational component where reported, the first-party / third-party sub-dimension split (see §6.3.1)  
+9. **Carbon Intensity Data**: Sources, temporal granularity, geographic coverage  
+10. **Limitations and Uncertainties**: Components with limited accuracy, excluded third-party services, estimation uncertainties, known gaps  
+11. **Calculation Date**: When the SCI for Web score was calculated  
+12. **Specification Version**: Version of SCI for Web specification used
+
+### 12.2 Recommended Disclosures
+
+1. **Component Breakdown**: Individual values for each component  
+2. **Baseline Comparison**: Previous version or alternative implementation comparison  
+3. **Improvement Actions**: Sustainability actions taken between measurements  
+4. **Third-Party Details**: List of services measured, estimated, or excluded  
+5. **Device Testing Details**: Specific device models used for client-side measurement  
+6. **Geographic Distribution**: Server regions and user geographic distribution  
+7. **Temporal Patterns**: Carbon intensity variation during measurement period
+
+### 12.3 Disclosure Format
+
+Organizations SHOULD provide disclosures in structured, machine-readable format (JSON, YAML) in addition to human-readable documentation.
+
+## 13\. Handling of Edge Cases
+
+### 13.1 Static Site Generation
+
+- O\_server includes only energy to serve static files (web server, CDN edge)  
+- Build-time generation energy is excluded (development lifecycle)  
+- O\_client and O\_network included as normal
+
+### 13.2 Single Page Applications (SPAs)
+
+- Initial page load and all subsequent API calls included in functional unit  
+- Functional unit SHOULD represent complete user workflow, not just initial load  
+- Client-side hydration and ongoing JavaScript execution included in O\_client
+
+### 13.3 Progressive Web Applications (PWAs)
+
+- Online functionality included normally  
+- Offline functionality from cached resources: no O\_server or O\_network; O\_client still measured  
+- Service Worker execution included in O\_client
+
+### 13.4 Serverless and Edge Computing
+
+- Serverless function execution included in O\_server  
+- Cold start overhead included (represents actual resource consumption)  
+- Edge function execution at CDN nodes included in O\_server  
+- Allocation methodology for shared infrastructure SHALL be disclosed
+
+### 13.5 API-First Architectures
+
+- Backend API serving energy in O\_server  
+- Frontend application consuming APIs in O\_client  
+- Functional unit SHOULD represent end-user value delivery, not individual API calls
+
+## 14\. Measurement Period and Traffic Characterization
+
+### 14.1 Minimum Measurement Periods
+
+- **Entry tier**: Minimum 7 consecutive days  
+- **Standard tier**: Minimum 30 consecutive days or one complete business cycle (whichever is longer)  
+- **Advanced tier**: Continuous measurement with monthly or quarterly reporting
+
+### 14.2 Traffic Characterization
+
+Organizations SHALL disclose: average and peak traffic levels, traffic distribution (geographic, device types), deviation from typical traffic, and seasonal factors if applicable.
+
+### 14.3 Normalization
+
+When comparing SCI scores over time or across implementations, traffic patterns SHALL be normalized to ensure comparable functional unit denominator. Normalization methodology SHALL be disclosed.
+
+## 15\. Carbon Intensity Data Sources
+
+Organizations SHALL use location-based grid carbon intensity data. Recommended sources:
+
+- ElectricityMaps ([https://www.electricitymaps.com/](https://www.electricitymaps.com/))  
+- WattTime ([https://www.watttime.org/](https://www.watttime.org/))  
+- International Energy Agency (IEA) emission factors  
+- Regional/national grid operators' published carbon intensity data  
+- UNFCCC emission factors
+
+**Temporal granularity**:
+
+- Entry tier: Annual average acceptable  
+- Standard tier: Daily average minimum  
+- Advanced tier: Hourly recommended
+
+## 16\. Reference Devices
+
+To enable comparable client-side measurements, organizations SHOULD select devices representing their actual user base from the following categories:
+
+| Category | High-End | Mid-Range | Low-End |
+| :---- | :---- | :---- | :---- |
+| Desktop | Modern workstation (6+ core, dedicated GPU) | Standard desktop (4 core, integrated graphics) | Budget desktop (2 core, integrated graphics) |
+| Laptop | Performance laptop (MacBook Pro 16" class) | Standard laptop (MacBook Air class) | Budget laptop (Chromebook class) |
+| Smartphone | Current generation flagship | Mid-tier smartphone | Budget or older generation |
+| Tablet | iPad Pro class | iPad Air class | Entry-level tablet |
+
+Organizations SHALL disclose device make, model, OS version, and browser version used for testing.
+
+## 17\. Core Characteristics
+
+As this specification develops, the following core characteristics SHALL remain true, extending those defined in the parent SCI specification:
+
+- **Sensitivity to web-specific sustainability actions**: Actions that reduce emissions in any component (client-side optimization, network transfer reduction, third-party service efficiency, distributed system carbon awareness, caching strategies) SHALL reduce SCI for Web scores.  
+    
+- **Systems-impact view across distributed architecture**: SCI for Web SHALL measure comprehensively across servers, networks, CDNs, third-party services, and client devices to prevent energy displacement.  
+    
+- **Progressive adoption enabling widespread implementation**: SCI for Web SHALL be implementable at different sophistication levels via implementation tiers, enabling teams with varying capabilities to adopt appropriate measurement.  
+    
+- **Encouragement of granular measurement with pragmatic defaults**: SCI for Web encourages the most granular measurement available while providing industry defaults for components where measurement is challenging.  
+    
+- **Prevention of gaming through comprehensive boundaries and disclosure**: SCI for Web SHALL resist gaming (energy displacement, quality degradation, boundary manipulation) through comprehensive boundaries, mandatory disclosure, and functional units measuring delivered value.  
+    
+- **Alignment with parent SCI principles**: All core characteristics of the parent SCI specification are preserved and extended with web-specific guidance.
+
+## 18\. Exclusions
+
+### 18.1 Market-Based Measures
+
+Following the parent SCI specification, the following SHALL NOT reduce SCI for Web scores:
+
+- Carbon offsets or credits  
+- Renewable Energy Credits (RECs)  
+- Power Purchase Agreements (PPAs) used to claim carbon-neutral energy  
+- Electricity Attribute Certificates (EACs)  
+- "Green hosting" certifications based solely on renewable energy purchases
+
+Carbon intensity calculations SHALL use location-based grid carbon intensity excluding market-based adjustments.
+
+### 18.2 Development and Testing Infrastructure
+
+Development infrastructure is excluded from SCI for Web scores:
+
+- Developer workstations  
+- CI/CD pipelines  
+- Build processes  
+- Automated testing systems  
+- Staging environments
+
+These MAY be measured separately using parent SCI methodology.
+
+## 19\. Baseline Comparison
+
+When comparing an improved implementation to a baseline, organizations SHALL:
+
+1. Maintain identical functional unit  
+2. Maintain identical software boundary  
+3. Use equivalent traffic profiles  
+4. Apply consistent methodology  
+5. Document what changed between baseline and comparison  
+6. Disclose both scores with methodology
+
+## 20\. Bibliography
+
+\[1\] *Software Carbon Intensity (SCI) Specification v1.1.0*, Green Software Foundation, [https://sci.greensoftware.foundation/](https://sci.greensoftware.foundation/)
+
+\[2\] *Sustainable Web Design Model v4*, Sustainable Web Design Community Group, [https://sustainablewebdesign.org/calculating-digital-emissions/](https://sustainablewebdesign.org/calculating-digital-emissions/)
+
+\[3\] *Web Sustainability Guidelines (WSG)*, W3C, [https://www.w3.org/TR/web-sustainability-guidelines/](https://www.w3.org/TR/web-sustainability-guidelines/)
+
+\[4\] *Greenhouse Gas Protocol ICT Sector Guidance*, GHG Protocol, [https://ghgprotocol.org/](https://ghgprotocol.org/)
+
+\[5\] *The Net-Zero Standard*, Science Based Targets initiative (SBTi), [https://sciencebasedtargets.org/net-zero](https://sciencebasedtargets.org/net-zero)
+
+\[6\] *CO2.js Documentation*, Green Web Foundation, [https://developers.thegreenwebfoundation.org/co2js/overview/](https://developers.thegreenwebfoundation.org/co2js/overview/)
+
+\[7\] *Boavizta Environmental Footprint Data*, Boavizta, [https://www.boavizta.org/](https://www.boavizta.org/)
+
+\[8\] *Cloud Carbon Footprint Methodology*, Cloud Carbon Footprint, [https://www.cloudcarbonfootprint.org/docs/methodology](https://www.cloudcarbonfootprint.org/docs/methodology)
+
+---
+
+## Appendices
+
+### Appendix A: Disclosure Template
+
+(To be developed: Structured JSON/YAML template for mandatory and recommended disclosures)
+
+### Appendix A.1: Non-Normative Implementation Templates
+
+The following templates are illustrative only and not normative. They are provided to help organizations structure their disclosures and internal analysis. Organizations SHOULD adapt them to their context.
+
+#### A.1.1 M\_network Materiality Analysis Template
+
+Use when evaluating whether M\_network can justifiably be declared unpopulated.
+
+```
+Application profile:
+  - Application type:           [e.g., streaming / e-commerce / SaaS / informational]
+  - Network-intensive?          [yes / no — justification]
+  - Primary traffic type:       [cellular / fixed / mixed, with estimated breakdown]
+
+Materiality estimate (using rough defaults):
+  - M_server (estimated):       [X kg CO2eq / month]
+  - M_client (estimated):       [Y kg CO2eq / month]
+  - M_network (estimated, industry-default basis): [Z kg CO2eq / month]
+  - Ratio:                      M_network / (M_server + M_network + M_client) = [%]
+
+Data sources evaluated:
+  - [e.g., Boavizta network hardware dataset — accessed / rejected because …]
+  - [e.g., vendor X sustainability report — available / unavailable]
+
+Decision:
+  [ ] Populate M_network at Standard Tier using [allocation basis]
+  [ ] Declare unpopulated — ratio < 5% and application is not network-intensive
+
+Revisit cadence:
+  [ ] Annual review scheduled for [date]
+  [ ] Trigger events: [new data source / app profile change / vendor disclosure]
+```
+
+#### A.1.2 Functional Unit Selection Template (Multi-Purpose Applications)
+
+Use when an application serves distinctly different user journeys.
+
+```
+Application overview:
+  - Primary value-delivery pathways:
+     1. [journey name — e.g., "purchase completed"]
+     2. [journey name — e.g., "search performed"]
+     3. [journey name — e.g., "account management session"]
+
+Per-journey FU definition:
+  For each journey above:
+    - Name:                     [FU name]
+    - Measurement source:       [analytics event / server log / synthetic]
+    - Engagement threshold:     [if applicable, with rationale]
+    - First-party / third-party attribution approach: [method]
+    - Expected comparability:   [cross-org at per-FU level / internal-only]
+
+Reporting plan:
+  [ ] Report per-FU SCI for each journey
+  [ ] Do not construct a single aggregate headline SCI
+  [ ] Declare maturity level: [number of FUs tracked]
+
+Governance:
+  - Owner(s) of each FU definition:   [product / engineering / sustainability]
+  - Review cadence:                   [e.g., quarterly]
+```
+
+#### A.1.3 O\_client First-Party / Third-Party Attribution Example
+
+Illustrative per the §6.3.1 mandatory disclosure.
+
+```
+Component:     O_client
+Total:         4.2 g CO2eq per completed transaction
+Breakdown:
+  O_client_first:  3.1 g CO2eq  (74% — application JavaScript, rendering, assets)
+  O_client_third:  1.1 g CO2eq  (26% — Google Analytics 0.4g, Intercom 0.5g,
+                                  Stripe.js 0.2g)
+
+Measurement approach:
+  - Long Tasks API for JavaScript execution time by origin (sampled RUM)
+  - Resource Timing API for asset load energy attribution
+  - Script bundle size × device-mix-weighted energy coefficient as fallback
+    where attribution is impractical
+
+Limitations disclosed:
+  - Google Analytics: client-side execution partially estimated because the
+    script does not expose fine-grained execution telemetry
+```
+
+#### A.1.4 CDN Bundled-Vendor-Data Allocation Template
+
+Use when the CDN provider publishes a single bundled energy figure.
+
+```
+Vendor figure:
+  - Source:                     [e.g., CDN provider sustainability portal]
+  - Period:                     [e.g., 2026-01-01 to 2026-01-31]
+  - Bundled energy:             [X kWh] for this application's traffic
+  - Carbon intensity applied:   [y gCO2eq/kWh — source]
+  - Bundled carbon:             [X * y] gCO2eq
+
+Allocation rule:
+  - Rationale:                  [e.g., cache-hit ratio split]
+  - Split:                      [e.g., 70% O_network / 30% O_server]
+  - Assumptions:                [e.g., cache hits are transmission-only;
+                                 dynamic edge functions are compute-equivalent]
+  - Data sources for split:     [e.g., CDN analytics dashboard]
+
+Disclosure statement:
+  "Allocation will transition to vendor-component-specific figures if/when
+   the provider publishes them."
+```
+
+### Appendix B: Worked Calculation Examples
+
+(To be developed: Step-by-step calculations for each application type with realistic data)
+
+### Appendix C: Reference Values and Coefficients
+
+(To be developed: Compiled reference values for embodied emissions, network energy coefficients, PUE defaults, and other constants)
+
+### Appendix D: Tool and Data Source Directory
+
+(To be developed: Curated list of measurement tools, instrumentation approaches, and data sources for each component)
+
+---
+
+## Document History
+
+**Version 0.2.0-draft** (2026-02-18): First draft specification based on REPORT.md design requirements, structured to align with SCI for AI specification format.
+
+**Future versions**: This specification will evolve through expert assembly, community feedback, implementation experience, and alignment with parent SCI specification updates.


### PR DESCRIPTION
Hi folks! 

I'm using the [same PR hack we used last time](https://github.com/w3c/sustainableweb-wsg/pull/199/changes), to share a work in progress snapshot of the files being developed in the SCI web assembly. 

You can see the full report that was created as a result of the last bit of work at the link below:
https://greensoftware.foundation/standards/sci-web/

This one will eventually result in an updated spec.md file - we expect deliberation and consensus building to go on over the summer. 

### Things to pay attention to 

Because we are working through the spec section by section, there may be cases where the spec is not yet consistent.

So far we have managed to work through:

1. Session 1: Formula Structure and Functional Units

We  are currently working through:

2 . Session 2: Server-Side and Network Measurement

you can see the full list at the link below
https://github.com/thegreenwebfoundation/sustainableweb-wsg/blob/ca-sci-web-snapshot-2026-05-07/sci-web/docs/phase-2/assembly-plan.md



