### PR TITLE
Fix typo: utlisation -> utilisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2620,7 +2620,7 @@
 				<section class="notoc" data-materials="low" data-energy="low" data-water="low" data-emissions="low" data-standard="AWS WAF, Azure WAF, GPF" data-considerations="Security" data-categories="AI, Performance, Software">
 					<h4 id="necessary-tasks">Success Criterion: Necessary tasks</h4>
 					<p class="external"><a class="urls" href="https://w3c.github.io/sustainableweb-wsg/resources.html#HIS06-2">Resources</a></p>
-					<p>Run automated tasks only when necessary to reduce unnecessary resources/resource utlisation/processing cycles.</p>
+					<p>Run automated tasks only when necessary to reduce unnecessary resources/resource utilisation/processing cycles.</p>
 				</section>
 				<section class="notoc" data-materials="low" data-energy="low" data-water="low" data-emissions="low" data-standard="AWS WAF, Azure WAF, GR491" data-considerations="Security" data-categories="Performance, Software">
 					<h4 id="automated-scaling">Success Criterion: Automated scaling</h4>

--- a/quickref.html
+++ b/quickref.html
@@ -403,7 +403,7 @@
 				<fieldset>
 					<legend><a href="https://www.w3.org/TR/web-sustainability-guidelines/#use-automation-wisely">4.6 Use automation wisely</a></legend>
 					<label><input type="checkbox"><span>Automate recurring tasks, such as deployment, testing, and compilation in alignment with continuous integration and continuous delivery best practices.</span></label>
-					<label><input type="checkbox"><span>Run automated tasks only when necessary to reduce unnecessary resources/resource utlisation/processing cycles.</span></label>
+					<label><input type="checkbox"><span>Run automated tasks only when necessary to reduce unnecessary resources/resource utilisation/processing cycles.</span></label>
 					<label><input type="checkbox"><span>Use automated scaling to adjust server capacity based on demand, ensuring efficient resource allocation during traffic spikes. Implement buffering and throttling to manage load and maintain performance without overprovisioning. Also use automation to promptly scale resources back down based on demand.</span></label>
 					<label><input type="checkbox"><span>Restrict the activity of unwanted and unnecessary third-party crawlers, suspicious user agents, unwanted users, bots, and scrapers from accessing or downloading your content. Follow best practices, such as server access rules and security tools, while ensuring your content remains accessible to users, search engines and any helpful, welcome crawlers. Consider that scrapers may be used to inform and train large language models.</span></label>
 					<p><strong>GRI:</strong> Low (Materials) / Low (Energy) / Low (Water) / Low (Emissions)</p>


### PR DESCRIPTION
Fixes #333

`utlisation` → `utilisation` in both `index.html` (line 2623) and `quickref.html` (line 406).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yosinn1-blip/sustainableweb-wsg/pull/346.html" title="Last updated on May 23, 2026, 9:05 PM UTC (6cd4090)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/346/5338fd2...yosinn1-blip:6cd4090.html" title="Last updated on May 23, 2026, 9:05 PM UTC (6cd4090)">Diff</a>