### PR TITLE
Use DEJI consistently in place of DEIJ

### DIFF
--- a/guidelines.json
+++ b/guidelines.json
@@ -1278,19 +1278,19 @@
 					"id": "use-diversity-equity-justice-inclusion-deji-practices",
 					"url": "https://www.w3.org/TR/web-sustainability-guidelines/#use-diversity-equity-justice-inclusion-deji-practices",
 					"guideline": "Use Diversity, Equity, Justice, Inclusion (DEJI) practices",
-					"subheading": "Publish and act on Diversity, Equity, Justice, Inclusion (DEIJ) and accessibility commitments, support training and measurable progress, and ensure inclusive outcomes across products and operations.",
+					"subheading": "Publish and act on Diversity, Equity, Justice, Inclusion (DEJI) and accessibility commitments, support training and measurable progress, and ensure inclusive outcomes across products and operations.",
 					"criteria": [
 						{
 							"title": "DEJI practices",
-							"description": "Publish clear commitments to DEIJ. Explain how the organization applies these commitments to reduce exclusion and support the long-term sustainability of access to the product for diverse and underserved or marginalized communities."
+							"description": "Publish clear commitments to DEJI. Explain how the organization applies these commitments to reduce exclusion and support the long-term sustainability of access to the product for diverse and underserved or marginalized communities."
 						},
 						{
 							"title": "DEJI training",
-							"description": "Provide DEIJ training and topics such as algorithmic bias, the digital divide, employment equity, mis- and disinformation."
+							"description": "Provide DEJI training and topics such as algorithmic bias, the digital divide, employment equity, mis- and disinformation."
 						},
 						{
 							"title": "DEJI improvements",
-							"description": "Track and publish measurable progress in DEIJ across hiring, leadership, and operations."
+							"description": "Track and publish measurable progress in DEJI across hiring, leadership, and operations."
 						}
 					],
 					"tags": ["Accessibility", "Ideation", "Social Equity", "Strategy"]

--- a/index.html
+++ b/index.html
@@ -2477,18 +2477,18 @@
 			</section>
 			<section> <!-- Use Diversity, Equity, Justice, Inclusion (DEJI) practices -->
 				<h3>Use Diversity, Equity, Justice, Inclusion (<abbr title="Diversity, Equity, Justice, Inclusion">DEJI</abbr>) practices</h3>
-				<p class="subheading">Publish and act on Diversity, Equity, Justice, Inclusion (DEIJ) and accessibility commitments, support training and measurable progress, and ensure inclusive outcomes across products and operations.</p>
+				<p class="subheading">Publish and act on Diversity, Equity, Justice, Inclusion (DEJI) and accessibility commitments, support training and measurable progress, and ensure inclusive outcomes across products and operations.</p>
 				<section class="notoc" data-people="high" data-planet="indeterminate" data-prosperity="indeterminate" data-timeframe="long" data-standard="SDGs" data-considerations="Accessibility" data-categories="Ideation, Social Equity, Strategy">
 					<h4 id="deji-practices">Success Criterion: DEJI practices</h4>
 					<p>Publish clear commitments to <abbr title="Diversity, Equity, Justice, Inclusion">DEJI</abbr>. Explain how the organization applies these commitments to reduce exclusion and support the long-term sustainability of access to the product for diverse and underserved or marginalized communities.</p>
 				</section>
 				<section class="notoc" data-people="high" data-planet="indeterminate" data-prosperity="indeterminate" data-timeframe="long" data-standard="GR491, SDGs" data-considerations="Accessibility" data-categories="Ideation, Social Equity, Strategy">
 					<h4 id="deji-training">Success Criterion: DEJI training</h4>
-					<p>Provide DEIJ training and topics such as algorithmic bias, the digital divide, employment equity, mis- and disinformation.</p>
+					<p>Provide DEJI training and topics such as algorithmic bias, the digital divide, employment equity, mis- and disinformation.</p>
 				</section>
 				<section class="notoc" data-people="high" data-planet="indeterminate" data-prosperity="indeterminate" data-timeframe="long" data-standard="SDGs" data-considerations="Accessibility" data-categories="Ideation, Social Equity, Strategy">
 					<h4 id="deji-improvements">Success Criterion: DEJI improvements</h4>
-					<p>Track and publish measurable progress in DEIJ across hiring, leadership, and operations.</p>
+					<p>Track and publish measurable progress in DEJI across hiring, leadership, and operations.</p>
 				</section>
 				<section class="notoc">
 					<h4>Additional information</h4>


### PR DESCRIPTION
The guideline under "Share decision-making power with affected parties" settles on **DEJI** in three separate places:

* the `h3`: "Use Diversity, Equity, Justice, Inclusion (DEJI) practices"
* the abbreviation: `<abbr title="Diversity, Equity, Justice, Inclusion">DEJI</abbr>`
* the three section IDs: `#deji-practices`, `#deji-training`, `#deji-improvements`

The prose then transposes the last two letters in seven places. This changes those seven to DEJI so everything matches the heading and the IDs.

`index.html`, three occurrences:

* line 2480, the subheading
* line 2487, Success Criterion: DEJI training
* line 2491, Success Criterion: DEJI improvements

`guidelines.json`, four occurrences: the `subheading` field plus the three `description` fields for the same guideline.

One thing this also clears up: `index.html` line 2483 currently reads "Publish clear commitments to DEJI" while the matching `description` in `guidelines.json` reads "commitments to DEIJ", so the two files disagreed on the same sentence. They agree now.

No wording changes beyond the acronym, and `guidelines.json` still parses.

I did not touch the section IDs, since they are already correct and changing them would break links.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Gabriel-Dalton/sustainableweb-wsg/pull/469.html" title="Last updated on Jul 29, 2026, 6:04 PM UTC (6fd75c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sustainableweb-wsg/469/65ef4e3...Gabriel-Dalton:6fd75c8.html" title="Last updated on Jul 29, 2026, 6:04 PM UTC (6fd75c8)">Diff</a>